### PR TITLE
Add logs to Datadog Agent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,3 +133,7 @@ volumes:
 networks:
   storedog-net:
     driver: bridge
+    ipam:
+      config:
+        - subnet: 172.18.0.0/16
+          gateway: 172.18.0.1


### PR DESCRIPTION
## Description

Please, provide here a short description.
Consider including things like:
- Add in the log functionality to the exisitng Datadog Agent

## How to test

-run `docker-compose down` and ensure the last output is `Removing network storedog-backend_storedog-net`
- run `docker network inspect storedog-backend_storedog-net` and you should get a `No such network` error
- run `docker-compose up` from the root
- run `docker network inspect storedog-backend_storedog-net`
- ensure that under `IPAM` the `Config` has a subnet of `172.18.0.0/16`

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
