### PR TITLE
remove port config from image

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,5 @@
 ADS_PORT=7676
 DISCOUNTS_PORT=2814
-ADS_ROUTE="http://advertisements"
-DISCOUNTS_ROUTE="http://discounts"
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 DD_API_KEY=

--- a/services/ads/Dockerfile
+++ b/services/ads/Dockerfile
@@ -22,12 +22,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Set default Flask app and development environment
 ENV FLASK_APP=ads.py
 
-# Pass in Port mapping (default to 9292)
-ARG ADS_PORT=9292
-# Because CMD is a runtime instruction, we have to create an additional ENV var that reads the ARG val
-# Only ENV vars are accessible via CMD
-ENV ADS_PORT ${ADS_PORT}
-
 # Start the app using ddtrace so we have profiling and tracing
 ENTRYPOINT ["ddtrace-run"]
-CMD flask run --port=${ADS_PORT} --host=0.0.0.0
+CMD flask run --port=9292 --host=0.0.0.0

--- a/services/discounts/Dockerfile
+++ b/services/discounts/Dockerfile
@@ -22,12 +22,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Let Flask know what to boot
 ENV FLASK_APP=discounts.py
 
-# Pass in Port mapping (default to 8282)
-ARG DISCOUNTS_PORT=8282
-# Because CMD is a runtime instruction, we have to create an additional ENV var that reads the ARG val
-# Only ENV vars are accessible via CMD
-ENV DISCOUNTS_PORT ${DISCOUNTS_PORT}
-
 # Start the app using ddtrace so we have profiling and tracing
 ENTRYPOINT ["ddtrace-run"]
-CMD flask run --port=${DISCOUNTS_PORT} --host=0.0.0.0
+CMD flask run --port=8282 --host=0.0.0.0


### PR DESCRIPTION
## Description

Passing in the port as an ARG to the Dockerfile doesn't make sense because in labs, we use prebuilt images and change the port via overrding `command` line in the docker compose for `ads` and `discounts`. So I cleaned up the Dockerfiles.

I also removed the routes for ads and discounts because the only possible route is localhost, because both requests are made client-side

## How to test
1. Change the port in the .env file
2. Start backend
3. Change the port in frontend in the .env.local file to match the ports in step 1
4. Start frontend
Expect: Ads and Discounts to be pulled through on the configured port

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
