### PR TITLE
Add CMD for backend Dockerfile

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - storedog-net
   web:
     image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.1
-    command: bash -c "rm -rf tmp/pids/server.pid && yarn install && yarn build && bundle exec rails s -b 0.0.0.0 -p 4000"
     depends_on:
       - 'postgres'
       - 'redis'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - 'redis'
     build:
       context: ./services/backend
-    command: bash -c "rm -rf tmp/pids/server.pid && yarn install && yarn build && bundle exec rails s -b 0.0.0.0 -p 4000"
     ports:
       - '${DOCKER_HOST_WEB_PORT:-4000}:4000'
     volumes:

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -40,4 +40,4 @@ COPY . .
 
 EXPOSE 4000
 
-CMD ["bash"]
+CMD ["/bin/bash", "-c", "rm -rf tmp/pids/server.pid && yarn install && yarn build && bundle install && bundle exec rails s -b 0.0.0.0 -p 4000"]


### PR DESCRIPTION
## Description

Add the container startup command into the Dockerfile instead of overriding it in the compose file. It was originally added in the compose to give the end user the ability to customize the backend port, but that doesn't seem to be a necessary use-case

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
