### PR TITLE
Fix discount port mapping

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     networks:
       - storedog-net
   web:
-    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.4
+    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.7
     depends_on:
       - 'postgres'
       - 'redis'
@@ -38,7 +38,7 @@ services:
     networks:
       - storedog-net
   worker:
-    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.4
+    image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.7
     command: bundle exec sidekiq -C config/sidekiq.yml
     depends_on:
       - 'postgres'
@@ -54,7 +54,7 @@ services:
     networks:
       - storedog-net
   ads:
-    image: public.ecr.aws/x2b9z2t7/storedog/ads:1.0.4
+    image: public.ecr.aws/x2b9z2t7/storedog/ads:1.0.7
     command: flask run --port=${ADS_PORT} --host=0.0.0.0
     depends_on:
       - postgres
@@ -74,8 +74,8 @@ services:
     networks:
       - storedog-net
   discounts:
-    image: public.ecr.aws/x2b9z2t7/storedog/discounts:1.0.4
-    command: flask run --port=${DISCOUNTS_PORT} --host=0.0.0.0
+    image: public.ecr.aws/x2b9z2t7/storedog/discounts:1.0.7
+    command: ./my-wrapper-script.sh ${DISCOUNTS_PORT}
     depends_on:
       - postgres
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,7 @@ services:
       - DD_APPSEC_ENABLED=true
     build:
       context: ./services/discounts
+    command: ./my-wrapper-script.sh ${DISCOUNTS_PORT}
     volumes:
       - ./services/discounts:/app
     ports:


### PR DESCRIPTION
## Description

This fixes an issue discovered by @devindford where frontend cannot connect to the discounts service. The issue is that the dynamic port mapping was not being respected by the discounts container after the start command was changed during a recent PR. This fixes the issue by re-introducing the override `command` inside the docker-compose file.

## How to test
Pull down locally, start the backend and frontend. Make sure the `DISCOUNTS_PORT` env var is the same for both frontend and backend.

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
