### PR TITLE
removed volume mount from prod compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,6 @@ services:
       - 'dd-agent'
     networks:
       - storedog-network
-    volumes:
-      - './services/backend:/app'
     environment:
       - DD_AGENT_HOST=dd-agent
       - DD_ENV=${DD_ENV:-production}


### PR DESCRIPTION
## Description
The prod docker-compose file had a volume mount that won't always exist. Removed it from the file.

## How to test
Copy only the docker-compose.yml file to a lab
run `docker compose up -d`
use `docker compose ps` to confirm all services are running.

