### PR TITLE
Frontend Docker overhaul: multi-stage build and RUM env cleanup

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -49,7 +49,6 @@ ADS_B_PERCENT=0 # Set < 0 > 100 to split traffic between ads services
 # =============================================
 # Frontend Service Configuration
 # =============================================
-FRONTEND_COMMAND='npm run dev' # Command to run the frontend service (default: 'npm run dev', use 'npm run prod' for production)
 NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend # Service name for frontend service in Datadog
 NEXT_PUBLIC_FRONTEND_API_ROUTE=http://service-proxy:80 # base url for next.js API routes (default: 'http://service-proxy:80')
 NEXT_PUBLIC_SPREE_API_HOST=http://service-proxy/services/backend # base url for backend service (default: 'http://service-proxy/services/backend')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Storedog changelog
+
+Notable repo-level infrastructure and tooling changes are documented here.
+Service-specific changes live in each service's own `CHANGELOG.md`.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com).
+
+## [Unreleased]
+
+### Frontend Docker overhaul
+
+- Compose (`docker-compose.yml`, `docker-compose.dev.yml`) now builds the frontend from its multi-stage Dockerfile (dev uses `target: development`) and drops the `wait-for-it` / `${FRONTEND_COMMAND}` startup command.
+- Standardized the frontend service's Datadog environment variables on the `NEXT_PUBLIC_DD_*` naming, and removed the obsolete `FRONTEND_COMMAND` entry from `.env.template`.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,7 +27,8 @@ services:
   frontend:
     build:
       context: ./services/frontend
-    command: bash -c "wait-for-it backend:4000 -- ${FRONTEND_COMMAND:-npm run dev}"
+      dockerfile: Dockerfile
+      target: development
     depends_on:
       - worker
       - dd-agent
@@ -40,25 +41,18 @@ services:
     environment:
       - DD_AGENT_HOST=dd-agent
       - DD_ENV=${DD_ENV:-development}
-      - DD_SERVICE=store-frontend-api # used for Next.js API routes
-      - DD_VERSION=${NEXT_PUBLIC_DD_VERSION_FRONTEND-1.0.0}
-      - DD_RUNTIME_METRICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
       - DD_PROFILING_TIMELINE_ENABLED=true
       - DD_PROFILING_ALLOCATION_ENABLED=true
-      - NEXT_PUBLIC_DD_APPLICATION_ID=${NEXT_PUBLIC_DD_APPLICATION_ID:-DD_APPLICATION_ID-not-set}
-      - NEXT_PUBLIC_DD_CLIENT_TOKEN=${NEXT_PUBLIC_DD_CLIENT_TOKEN:-DD_CLIENT_TOKEN-not-set}
+      - DD_RUNTIME_METRICS_ENABLED=true
+      - DD_SERVICE=${NEXT_PUBLIC_DD_SERVICE_FRONTEND:-store-frontend}
+      - DD_VERSION=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
+      - NEXT_PUBLIC_DD_ENV=${NEXT_PUBLIC_DD_ENV:-development}
+      - NEXT_PUBLIC_DD_VERSION_FRONTEND=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
+      - NEXT_PUBLIC_DD_SERVICE_FRONTEND=${NEXT_PUBLIC_DD_SERVICE_FRONTEND:-store-frontend}
       - NEXT_PUBLIC_DD_SITE=${NEXT_PUBLIC_DD_SITE:-datadoghq.com}
-      - NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend # used for client-side Next.js RUM configuration
-      - NEXT_PUBLIC_DD_ENV=${DD_ENV:-development}
-      - NEXT_PUBLIC_ADS_ROUTE=${NEXT_PUBLIC_ADS_ROUTE:-/services/ads}
-      - NEXT_PUBLIC_DISCOUNTS_ROUTE=${NEXT_PUBLIC_DISCOUNTS_ROUTE:-/services/discounts}
-      - NEXT_PUBLIC_DBM_ROUTE=${NEXT_PUBLIC_DBM_ROUTE:-/services/dbm}
-      - NEXT_PUBLIC_FRONTEND_API_ROUTE=${NEXT_PUBLIC_FRONTEND_API_ROUTE:-http://localhost:3000}
-      - NEXT_PUBLIC_SPREE_API_HOST=${NEXT_PUBLIC_SPREE_API_HOST:-http://service-proxy/services/backend}
-      - NEXT_PUBLIC_SPREE_CLIENT_HOST=${NEXT_PUBLIC_SPREE_CLIENT_HOST:-/services/backend}
-      - NEXT_PUBLIC_SPREE_IMAGE_HOST=${NEXT_PUBLIC_SPREE_IMAGE_HOST:-/services/backend}
-      - NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN=${NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN:-service-proxy}
+      - NEXT_PUBLIC_DD_APPLICATION_ID=${NEXT_PUBLIC_DD_APPLICATION_ID:-not-set-in-docker-compose}
+      - NEXT_PUBLIC_DD_CLIENT_TOKEN=${NEXT_PUBLIC_DD_CLIENT_TOKEN:-not-set-in-docker-compose}
     labels:
       com.datadoghq.ad.logs: '[{"source": "nodejs", "auto_multi_line_detection": true }]'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - postgres_logs:/var/log/pg_log:ro
   frontend:
     image: ghcr.io/datadog/storedog/frontend:${STOREDOG_IMAGE_VERSION:-latest}
-    command: bash -c "wait-for-it backend:4000 -- ${FRONTEND_COMMAND:-npm run prod}"
     depends_on:
       - worker
       - dd-agent
@@ -31,18 +30,18 @@ services:
     environment:
       - DD_AGENT_HOST=dd-agent
       - DD_ENV=${DD_ENV:-production}
-      - DD_SERVICE=store-frontend-api # used for Next.js API routes
-      - DD_VERSION=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
-      - DD_RUNTIME_METRICS_ENABLED=true
       - DD_PROFILING_ENABLED=true
       - DD_PROFILING_TIMELINE_ENABLED=true
       - DD_PROFILING_ALLOCATION_ENABLED=true
-      - NEXT_PUBLIC_DD_APPLICATION_ID=${NEXT_PUBLIC_DD_APPLICATION_ID:-DD_APPLICATION_ID-not-set}
-      - NEXT_PUBLIC_DD_CLIENT_TOKEN=${NEXT_PUBLIC_DD_CLIENT_TOKEN:-DD_CLIENT_TOKEN-not-set}
+      - DD_RUNTIME_METRICS_ENABLED=true
+      - DD_SERVICE=${NEXT_PUBLIC_DD_SERVICE_FRONTEND:-store-frontend}
+      - DD_VERSION=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
+      - NEXT_PUBLIC_DD_ENV=${NEXT_PUBLIC_DD_ENV:-production}
+      - NEXT_PUBLIC_DD_VERSION_FRONTEND=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
+      - NEXT_PUBLIC_DD_SERVICE_FRONTEND=${NEXT_PUBLIC_DD_SERVICE_FRONTEND:-store-frontend}
       - NEXT_PUBLIC_DD_SITE=${NEXT_PUBLIC_DD_SITE:-datadoghq.com}
-      - NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend # used for client-side Next.js RUM configuration
-      - NEXT_PUBLIC_DD_ENV=${DD_ENV:-production}
-      - NEXT_PUBLIC_DD_VERSION=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
+      - NEXT_PUBLIC_DD_APPLICATION_ID=${NEXT_PUBLIC_DD_APPLICATION_ID:-not-set-in-docker-compose}
+      - NEXT_PUBLIC_DD_CLIENT_TOKEN=${NEXT_PUBLIC_DD_CLIENT_TOKEN:-not-set-in-docker-compose}
     labels:
       com.datadoghq.ad.logs: '[{"source": "nodejs", "auto_multi_line_detection": true }]'
   backend:

--- a/services/frontend/CHANGELOG.md
+++ b/services/frontend/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Frontend service changelog
+
+All notable changes to the frontend service are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com).
+
+## [Unreleased]
+
+### Added
+
+- Multi-stage `Dockerfile` with separate `development` and `production` build targets.
+- `standalone` output mode in `next.config.js` for the production build.
+
+### Changed
+
+- Reworked Datadog RUM configuration to use `NEXT_PUBLIC_DD_*` environment variables consistently.
+- Updated frontend dependencies (`package-lock.json`) and the `Ad` component.
+- Compose now builds the frontend from the multi-stage Dockerfile (dev `target: development`) instead of running a `wait-for-it` + `${FRONTEND_COMMAND}` command.
+
+### Removed
+
+- Obsolete `FRONTEND_COMMAND` indirection, replaced by build targets.

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -1,29 +1,135 @@
-FROM node:20 AS builder
+FROM node:lts-alpine AS base
 
-# install wait-for-it
-RUN apt-get update && apt-get install -y wait-for-it
+# Install system dependencies (this layer rarely changes)
+RUN apk add --no-cache netcat-openbsd && \
+    npm install -g @datadog/datadog-ci
 
-# install datadog-ci 
-RUN npm install -g @datadog/datadog-ci
+WORKDIR /app
 
+# Copy package files
+COPY package*.json ./
+
+# Development stage
+FROM base AS development
+
+# Install all dependencies (including devDependencies)
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Set development environment variables
+ARG NEXT_PUBLIC_DD_ENV=development
+ARG NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend
+ARG NEXT_PUBLIC_DD_SITE=datadoghq.com
+ARG NEXT_PUBLIC_DD_VERSION_FRONTEND=1.0.0
+ARG NEXT_PUBLIC_DD_APPLICATION_ID=not-set-in-dockerfile
+ARG NEXT_PUBLIC_DD_CLIENT_TOKEN=not-set-in-dockerfile
 ARG DD_GIT_REPOSITORY_URL
 ARG DD_GIT_COMMIT_SHA
 
+ENV NEXT_PUBLIC_DD_ENV=${NEXT_PUBLIC_DD_ENV}
+ENV NEXT_PUBLIC_DD_SERVICE_FRONTEND=${NEXT_PUBLIC_DD_SERVICE_FRONTEND}
+ENV NEXT_PUBLIC_DD_SITE=${NEXT_PUBLIC_DD_SITE}
+ENV NEXT_PUBLIC_DD_VERSION_FRONTEND=${NEXT_PUBLIC_DD_VERSION_FRONTEND}
+ENV NEXT_PUBLIC_DD_APPLICATION_ID=${NEXT_PUBLIC_DD_APPLICATION_ID}
+ENV NEXT_PUBLIC_DD_CLIENT_TOKEN=${NEXT_PUBLIC_DD_CLIENT_TOKEN}
+
 # Set default environment variables
 ENV NEXT_TELEMETRY_DISABLED=1 \
-  NEXT_PUBLIC_ADS_ROUTE=/services/ads \
-  NEXT_PUBLIC_DISCOUNTS_ROUTE=/services/discounts \
-  NEXT_PUBLIC_DBM_ROUTE=/services/dbm \
-  NEXT_PUBLIC_FRONTEND_API_ROUTE=http://service-proxy:80 \
-  NEXT_PUBLIC_SPREE_API_HOST=http://service-proxy/services/backend \
-  NEXT_PUBLIC_SPREE_CLIENT_HOST=/services/backend \
-  NEXT_PUBLIC_SPREE_IMAGE_HOST=/services/backend \
-  NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN=service-proxy \
-  DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL} \
-  DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+    NEXT_PUBLIC_ADS_ROUTE=/services/ads \
+    NEXT_PUBLIC_DISCOUNTS_ROUTE=/services/discounts \
+    NEXT_PUBLIC_DBM_ROUTE=/services/dbm \
+    NEXT_PUBLIC_FRONTEND_API_ROUTE=http://service-proxy:80 \
+    NEXT_PUBLIC_SPREE_API_HOST=http://service-proxy/services/backend \
+    NEXT_PUBLIC_SPREE_CLIENT_HOST=/services/backend \
+    NEXT_PUBLIC_SPREE_IMAGE_HOST=/services/backend \
+    NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN=service-proxy \
+    DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL} \
+    DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
 
-WORKDIR /app
-COPY package*.json ./
-RUN npm install
+CMD ["npm", "run", "dev"]
+
+# Builder stage for production
+FROM base AS builder
+
+# Install production dependencies only
+RUN npm ci --only=production && npm cache clean --force
+RUN npm install sharp
+
+# Copy source code
 COPY . .
-EXPOSE 3000
+
+# Set build-time environment variables
+ARG NEXT_PUBLIC_DD_VERSION_FRONTEND=1.0.0
+ARG NEXT_PUBLIC_DD_SITE=datadoghq.com
+ARG NEXT_PUBLIC_DD_ENV=production
+ARG NEXT_PUBLIC_DD_APPLICATION_ID=not-set-in-dockerfile
+ARG NEXT_PUBLIC_DD_CLIENT_TOKEN=not-set-in-dockerfile
+ARG DD_SERVICE=store-frontend
+
+ENV NEXT_PUBLIC_DD_VERSION_FRONTEND=${NEXT_PUBLIC_DD_VERSION_FRONTEND}
+ENV NEXT_PUBLIC_DD_SITE=${NEXT_PUBLIC_DD_SITE}
+ENV NEXT_PUBLIC_DD_ENV=${NEXT_PUBLIC_DD_ENV}
+ENV NEXT_PUBLIC_DD_APPLICATION_ID=${NEXT_PUBLIC_DD_APPLICATION_ID}
+ENV NEXT_PUBLIC_DD_CLIENT_TOKEN=${NEXT_PUBLIC_DD_CLIENT_TOKEN}
+ENV DD_SERVICE=${DD_SERVICE}
+
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PUBLIC_ADS_ROUTE=/services/ads \
+    NEXT_PUBLIC_DISCOUNTS_ROUTE=/services/discounts \
+    NEXT_PUBLIC_DBM_ROUTE=/services/dbm \
+    NEXT_PUBLIC_FRONTEND_API_ROUTE=http://service-proxy:80 \
+    NEXT_PUBLIC_SPREE_API_HOST=http://service-proxy/services/backend \
+    NEXT_PUBLIC_SPREE_CLIENT_HOST=/services/backend \
+    NEXT_PUBLIC_SPREE_IMAGE_HOST=/services/backend \
+    NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN=service-proxy
+
+# Build the application
+RUN npm run build
+
+# Production runner stage
+FROM base AS production
+
+# Install sharp for image optimization in standalone mode
+RUN npm install sharp
+
+# Don't run production as root
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+USER nextjs
+
+
+COPY --from=builder /app/public ./public
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# Set runtime environment variables
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PUBLIC_ADS_ROUTE=/services/ads \
+    NEXT_PUBLIC_DISCOUNTS_ROUTE=/services/discounts \
+    NEXT_PUBLIC_DBM_ROUTE=/services/dbm \
+    NEXT_PUBLIC_FRONTEND_API_ROUTE=http://service-proxy:80 \
+    NEXT_PUBLIC_SPREE_API_HOST=http://service-proxy/services/backend \
+    NEXT_PUBLIC_SPREE_CLIENT_HOST=/services/backend \
+    NEXT_PUBLIC_SPREE_IMAGE_HOST=/services/backend \
+    NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN=service-proxy
+
+ARG NEXT_PUBLIC_DD_VERSION_FRONTEND=1.0.0
+ARG NEXT_PUBLIC_DD_SITE=datadoghq.com
+ARG NEXT_PUBLIC_DD_ENV=production
+ARG NEXT_PUBLIC_DD_APPLICATION_ID=not-set-in-prod-dockerfile
+ARG NEXT_PUBLIC_DD_CLIENT_TOKEN=not-set-in-prod-dockerfile
+ARG NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend
+
+ENV NEXT_PUBLIC_DD_VERSION_FRONTEND=${NEXT_PUBLIC_DD_VERSION_FRONTEND}
+ENV NEXT_PUBLIC_DD_SITE=${NEXT_PUBLIC_DD_SITE}
+ENV NEXT_PUBLIC_DD_ENV=${NEXT_PUBLIC_DD_ENV}
+ENV NEXT_PUBLIC_DD_APPLICATION_ID=${NEXT_PUBLIC_DD_APPLICATION_ID}
+ENV NEXT_PUBLIC_DD_CLIENT_TOKEN=${NEXT_PUBLIC_DD_CLIENT_TOKEN}
+ENV NEXT_PUBLIC_DD_SERVICE_FRONTEND=${NEXT_PUBLIC_DD_SERVICE_FRONTEND}
+
+CMD ["node", "server.js"]

--- a/services/frontend/README.md
+++ b/services/frontend/README.md
@@ -1,6 +1,38 @@
-# Frontend service
-
-## Description
+# Frontend service README
 
 The frontend services is a JavaScript application that uses the Next.js React framework. It includes it's own set of API routes, which are used to fetch data from the backend services.
 
+## Environment variables
+
+Variables that Next.js uses are prefixed with `NEXT_PUBLIC_`. These variables must be set a build time.
+
+RUM SDK configuration:
+
+`NEXT_PUBLIC_DD_APPLICATION_ID`: The RUM Application ID
+`NEXT_PUBLIC_DD_CLIENT_TOKEN`: The Client Token for the RUM SDK
+`NEXT_PUBLIC_DD_ENV`: The `env` tag value for RUM data
+`NEXT_PUBLIC_DD_SERVICE_FRONTEND`: The `service` tag value for RUM data
+`NEXT_PUBLIC_DD_SITE`: The Datadog site
+`NEXT_PUBLIC_DD_VERSION_FRONTEND`: The `version` tag value for RUM data
+
+URLs used by the Next.js server:
+
+- `NEXT_PUBLIC_FRONTEND_API_ROUTE`=http://service-proxy:80 # base url for next.js API routes (default: 'http://service-proxy:80')
+- `NEXT_PUBLIC_SPREE_API_HOST`=http://service-proxy/services/backend # base url for backend service (default: 'http://service-proxy/services/backend')
+
+URLs used by client components:
+
+- `NEXT_PUBLIC_ADS_ROUTE`: base url for ads service
+- `NEXT_PUBLIC_DBM_ROUTE`base url for dbm service
+- `NEXT_PUBLIC_DISCOUNTS_ROUTE`: base url for discounts service
+- `NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN`: allowed image domain
+- `NEXT_PUBLIC_SPREE_CLIENT_HOST`: base url for backend service
+- `NEXT_PUBLIC_SPREE_IMAGE_HOST`: base url for backend service
+
+## The different build targets
+
+The `production` build target creates an optimized, standalone production build, which means that subsequent builds after the initial build are much faster.
+
+You need to rebuild when you change build-time variables (like any `NEXT_PUBLIC_` variable) or any mounted volumes. There's no hot reloading. But don't worry, the builds are fast.
+
+You probably don't need to use the `development` target except when developing/testing.

--- a/services/frontend/components/common/Ad/Ad.tsx
+++ b/services/frontend/components/common/Ad/Ad.tsx
@@ -16,21 +16,15 @@ function Ad() {
   const [isLoading, setLoading] = useState(false)
   const adsPath = process.env.NEXT_PUBLIC_ADS_ROUTE || `/services/ads`
 
-  const getRandomArbitrary = useCallback((min: number, max: number) => {
-    return Math.floor(Math.random() * (max - min) + min)
-  }, [])
-
   const fetchAd = useCallback(async () => {
     setLoading(true)
     const flag = (await codeStash('error-tracking', { file: config })) || false
-    console.log(adsPath)
     const headers = {
       'X-Throw-Error': `${flag}`,
       'X-Error-Rate': process.env.NEXT_PUBLIC_ADS_ERROR_RATE || '0.25',
     }
 
     try {
-      console.log('ads path', adsPath)
       // Add cache-busting parameter to ensure fresh data
       const timestamp = Date.now()
       const res = await fetch(`${adsPath}/ads?t=${timestamp}`, { headers })
@@ -38,7 +32,6 @@ function Ad() {
         throw new Error('Error fetching ad')
       }
       const data: Advertisement[] = await res.json()
-      console.log('Available ads:', data)
       // Sort ads by ID to ensure consistent ordering
       const sortedAds = data.sort((a, b) => a.id - b.id)
       // Use a deterministic selection based on time to show different ads
@@ -46,24 +39,16 @@ function Ad() {
       const now = new Date()
       const adIndex = Math.floor(now.getSeconds() / 5) % sortedAds.length // Change ad every 5 seconds
       const selectedAd = sortedAds[adIndex]
-      console.log('Selected ad:', selectedAd)
       setData(selectedAd)
       setLoading(false)
     } catch (e) {
       console.error(e)
       setLoading(false)
     }
-  }, [adsPath, getRandomArbitrary, setData, setLoading])
+  }, [adsPath, setData, setLoading])
 
   const handleAdClick = useCallback(() => {
     if (data?.id) {
-      console.log('Ad clicked!', {
-        adId: data.id,
-        adName: data.name,
-        clickUrl: data.clickUrl,
-        imagePath: data.path,
-        redirectUrl: `${adsPath}/click/${data.id}`
-      })
       // Direct browser navigation to the click endpoint
       // The Java service will handle the redirect to the appropriate URL
       window.location.href = `${adsPath}/click/${data.id}`
@@ -76,13 +61,13 @@ function Ad() {
 
   if (isLoading)
     return (
-      <div className="flex flex-row justify-center h-10 advertisment-wrapper">
+      <div className="flex flex-row justify-center h-10 advertisement-wrapper">
         AD HERE
       </div>
     )
   if (!data)
     return (
-      <div className="flex flex-row justify-center h-10 advertisment-wrapper">
+      <div className="flex flex-row justify-center h-10 advertisement-wrapper">
         AD DIDN'T LOAD
       </div>
     )

--- a/services/frontend/next.config.js
+++ b/services/frontend/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  output: 'standalone',
   productionBrowserSourceMaps: true,
   eslint: {
     // Warning: This allows production builds to successfully complete even if

--- a/services/frontend/package-lock.json
+++ b/services/frontend/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@datadog/browser-rum": "^6.6.2",
+        "@datadog/browser-rum": "^6.19.0",
         "@radix-ui/react-dropdown-menu": "^0.1.6",
         "@react-spring/web": "^9.4.1",
         "autoprefixer": "^10.4.2",
         "body-scroll-lock": "^4.0.0-beta.0",
         "clsx": "^1.1.1",
         "code-stash": "https://origin-static-assets.s3.amazonaws.com/corp-node-packages/master/code-stash-v1.0.5.tgz",
-        "dd-trace": "^5.56.0",
+        "dd-trace": "^5.67.0",
         "keen-slider": "^6.6.3",
         "lodash.random": "^3.2.0",
         "lodash.throttle": "^4.1.1",
@@ -454,22 +454,22 @@
       }
     },
     "node_modules/@datadog/browser-core": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.12.3.tgz",
-      "integrity": "sha512-PXtLAszdaEMnGcIF2KT3cuLZJ32vmxfsRujvTaibOFPuTDO/1uItozDR9D1XbfknDGV3KaU2WY7fDExv4PABHQ==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.22.0.tgz",
+      "integrity": "sha512-f4c5y3HYR879+vZgwos3hPxTX8XvNCNmujSpSmA8zdIVA1JgP3Ern8Up2x4LEPGVxgSojUy8pVVtf3rjKXRjZg==",
       "license": "Apache-2.0"
     },
     "node_modules/@datadog/browser-rum": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-6.12.3.tgz",
-      "integrity": "sha512-cr0ddLvXXobY/dR63oYlTgA9MKFw7fQwYWe1IRa51jw1u4jULLVibW1TtiWVCt5sM+VYoYbs28tLB5ySrCUOUg==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-6.22.0.tgz",
+      "integrity": "sha512-6AQUuu3tWwCp0fgRBDE1Qscm/DTLtaK3e8L9tJa1YRw1wvg41CGRm2jgF3yRz6WXvsz/gTqmq+QBjDzSl8UbWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@datadog/browser-core": "6.12.3",
-        "@datadog/browser-rum-core": "6.12.3"
+        "@datadog/browser-core": "6.22.0",
+        "@datadog/browser-rum-core": "6.22.0"
       },
       "peerDependencies": {
-        "@datadog/browser-logs": "6.12.3"
+        "@datadog/browser-logs": "6.22.0"
       },
       "peerDependenciesMeta": {
         "@datadog/browser-logs": {
@@ -478,24 +478,36 @@
       }
     },
     "node_modules/@datadog/browser-rum-core": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-6.12.3.tgz",
-      "integrity": "sha512-7JYjmgZb67HCBha/w689sekQsVIVAjYTUG6fDualOo9I80Wz+YjAD9pyrKDaRShIk6bupfnTYm5GSmh+iG8c5A==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-6.22.0.tgz",
+      "integrity": "sha512-Du6poAHIHNFk5Cz3YBxNTnaCGrRJVTzCrOIpcfwPajbUYYGw1VT0KKyq5OBUIaxNFpPTv+UuIoI5689a0Tyb2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@datadog/browser-core": "6.12.3"
+        "@datadog/browser-core": "6.22.0"
+      }
+    },
+    "node_modules/@datadog/flagging-core": {
+      "version": "0.1.0-preview.10",
+      "resolved": "https://registry.npmjs.org/@datadog/flagging-core/-/flagging-core-0.1.0-preview.10.tgz",
+      "integrity": "sha512-E1jRY80xqgL9Hie3vGbQUiK8FXijeN+h9DHXourcPgw+F2fiQ3m1sLTNrjrZTOOpKfhJE/lvahssQpMRtQh1TA==",
+      "license": "MIT",
+      "dependencies": {
+        "spark-md5": "^3.0.2"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.8.1"
       }
     },
     "node_modules/@datadog/libdatadog": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.6.0.tgz",
-      "integrity": "sha512-Ldu+U59LUnejtd7ceXMKJCAFZeYpNdTEEXr8PISY9HFXMa4DOwepcWMaJAAqCPU7LINJeivVwvSD1Pm14VZy7w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@datadog/libdatadog/-/libdatadog-0.7.0.tgz",
+      "integrity": "sha512-VVZLspzQcfEU47gmGCVoRkngn7RgFRR4CHjw4YaX8eWT+xz4Q4l6PvA45b7CMk9nlt3MNN5MtGdYttYMIpo6Sg==",
       "license": "Apache-2.0"
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-8.5.2.tgz",
-      "integrity": "sha512-lETBaVhBk+9o0pc+LDnXvp2ImDyT8K2deuqLf8A6q4/QjzCCXyR/yZO9R5+Kdoc93jZMRTWV9Pr4pBwHEdJSVA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-10.2.1.tgz",
+      "integrity": "sha512-FwRVo+otgNaz6vN74XVrBT8GdLwxPwAqOjH4Y9VQJaC1RiHmzRCMr77AhHFme1xi7zPG2LQqQN/cmOzG+sbrtQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -529,17 +541,33 @@
         "node": ">=16"
       }
     },
+    "node_modules/@datadog/openfeature-node-server": {
+      "version": "0.1.0-preview.10",
+      "resolved": "https://registry.npmjs.org/@datadog/openfeature-node-server/-/openfeature-node-server-0.1.0-preview.10.tgz",
+      "integrity": "sha512-btTKlz80Gn2Xj0m2LR9ZKkoB/Wybu4mFa86wPJv3G1IKU61wgPpvdIILDEwDz+lg5gLjxxeJM50r4tP82bEteQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@datadog/flagging-core": "0.1.0-preview.10",
+        "@openfeature/server-sdk": "~1.18.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@openfeature/server-sdk": "~1.18.0"
+      }
+    },
     "node_modules/@datadog/pprof": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.8.2.tgz",
-      "integrity": "sha512-M+bO4v4TaxYK6k2qJBxnhf7Vh25Wode64y4LfxzGs5kLTFr8eFTp6HJai3/af7U5gjTHX/4s+CHv2bxja97pbw==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.11.1.tgz",
+      "integrity": "sha512-DX3F0v0BVOuP7RUBiu7bDhuGfFfICJRcElB+ZrEykMvkvBXe7FdVXoybYFviLH177hulwYTtW9Rcly7NXGarTw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "delay": "^5.0.0",
         "node-gyp-build": "<4.0",
         "p-limit": "^3.1.0",
-        "pprof-format": "^2.1.0",
+        "pprof-format": "^2.2.1",
         "source-map": "^0.7.4"
       },
       "engines": {
@@ -807,6 +835,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@next/bundle-analyzer": {
@@ -1078,11 +1130,42 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
-      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+    "node_modules/@openfeature/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==",
       "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.18.0.tgz",
+      "integrity": "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.206.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.206.0.tgz",
+      "integrity": "sha512-yIVDu9jX//nV5wSMLZLdHdb1SKHIMj9k+wQVFtln5Flcgdldz9BkHtavvExQiJqBZg2OpEEJEZmzQazYztdz2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1100,6 +1183,46 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.9.1.tgz",
+      "integrity": "sha512-VqBGbnAfubI+l+yrtYxeLyOoL358JK57btPMJDd3TCOV3mV5TNBmzvOfmesM4NeTyXuGJByd3XvOHvFezLn3rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.9.1",
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
+      "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -2914,46 +3037,49 @@
       }
     },
     "node_modules/dc-polyfill": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.9.tgz",
-      "integrity": "sha512-D5mJThEEk9hf+CJPwTf9JFsrWdlWp8Pccjxkhf7uUT/E/cU9Mx3ebWe2Bz2OawRmJ6WS9eaDPBkeBE4uOKq9uw==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.10.tgz",
+      "integrity": "sha512-9iSbB8XZ7aIrhUtWI5ulEOJ+IyUN+axquodHK+bZO4r7HfY/xwmo6I4fYYf+aiDom+WMcN/wnzCz+pKvHDDCug==",
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
     },
     "node_modules/dd-trace": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.56.0.tgz",
-      "integrity": "sha512-1GiAh1UATmn8uZxk+nqZAdfJppiOq4kxJKiozMNvupffbcbAuDj5qnfYF9Hz3oqsk+Jtt2oheQeR05c4JRshXw==",
+      "version": "5.72.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.72.0.tgz",
+      "integrity": "sha512-3lH4RIJqzpjIvEISkbDBqPB7M4XDwrcj3r4zcF0LXgKYdyzU/Ebo/8uy+0XWaQBqj2kYERDw2lpJVLb0AbzNdw==",
       "hasInstallScript": true,
       "license": "(Apache-2.0 OR BSD-3-Clause)",
       "dependencies": {
-        "@datadog/libdatadog": "^0.6.0",
-        "@datadog/native-appsec": "8.5.2",
+        "@datadog/libdatadog": "0.7.0",
+        "@datadog/native-appsec": "10.2.1",
         "@datadog/native-iast-taint-tracking": "4.0.0",
-        "@datadog/native-metrics": "^3.1.1",
-        "@datadog/pprof": "5.8.2",
-        "@datadog/sketches-js": "^2.1.1",
+        "@datadog/native-metrics": "3.1.1",
+        "@datadog/openfeature-node-server": "0.1.0-preview.10",
+        "@datadog/pprof": "5.11.1",
+        "@datadog/sketches-js": "2.1.1",
         "@datadog/wasm-js-rewriter": "4.0.1",
         "@isaacs/ttlcache": "^1.4.1",
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "^1.14.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/api-logs": "<1.0.0",
+        "@opentelemetry/core": ">=1.14.0 <1.31.0",
+        "@opentelemetry/resources": ">=1.0.0 <1.10.0",
         "crypto-randomuuid": "^1.0.0",
-        "dc-polyfill": "0.1.9",
-        "ignore": "^5.2.4",
-        "import-in-the-middle": "1.14.0",
-        "istanbul-lib-coverage": "3.2.2",
+        "dc-polyfill": "^0.1.10",
+        "ignore": "^7.0.5",
+        "import-in-the-middle": "^1.14.2",
+        "istanbul-lib-coverage": "^3.2.2",
         "jest-docblock": "^29.7.0",
-        "koalas": "^1.0.2",
-        "limiter": "1.1.5",
+        "jsonpath-plus": "^10.3.0",
+        "limiter": "^1.1.5",
         "lodash.sortby": "^4.7.0",
-        "lru-cache": "^7.18.3",
+        "lru-cache": "^10.4.3",
         "module-details-from-path": "^1.0.4",
         "mutexify": "^1.4.0",
-        "opentracing": ">=0.12.1",
+        "opentracing": ">=0.14.7",
         "path-to-regexp": "^0.1.12",
-        "pprof-format": "^2.1.0",
+        "pprof-format": "^2.1.1",
         "protobufjs": "^7.5.3",
         "retry": "^0.13.1",
         "rfdc": "^1.4.1",
@@ -2965,7 +3091,34 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.9.0",
+        "@openfeature/server-sdk": "~1.18.0"
+      },
+      "peerDependenciesMeta": {
+        "@openfeature/core": {
+          "optional": true
+        },
+        "@openfeature/server-sdk": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/dd-trace/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/dd-trace/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -4483,6 +4636,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4505,9 +4659,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.0.tgz",
-      "integrity": "sha512-g5zLT0HaztRJWysayWYiUq/7E5H825QIiecMD2pI5QO7Wzr847l6GDvPvmZaDIdrDtS2w7qRczywxiK6SL5vRw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -5105,6 +5259,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5145,6 +5308,24 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonpath-plus": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -5175,15 +5356,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/koalas": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/koalas/-/koalas-1.0.2.tgz",
-      "integrity": "sha512-RYhBbYaTTTHId3l6fnMZc3eGQNW6FVCqMG6AMwA5I1Mafr6AflaXeoi6x3xQuATRotGYRLk6+1ELZH4dstFNOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -7119,9 +7291,9 @@
       "license": "MIT"
     },
     "node_modules/pprof-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.1.0.tgz",
-      "integrity": "sha512-0+G5bHH0RNr8E5hoZo/zJYsL92MhkZjwrHp3O2IxmY8RJL9ooKeuZ8Tm0ZNBw5sGZ9TiM71sthTjWoR2Vf5/xw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.2.1.tgz",
+      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -7938,12 +8110,12 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -7954,6 +8126,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/split2": {
       "version": "4.2.0",


### PR DESCRIPTION
f## Summary
- Wires the frontend service to its multi-stage `Dockerfile` (dev uses `target: development`) and enables `standalone` Next.js output for production.
- Standardizes the frontend's Datadog RUM env vars on `NEXT_PUBLIC_DD_*` in both compose files and drops the obsolete `wait-for-it`/`FRONTEND_COMMAND` startup indirection (removed from `.env.template`).
- Updates frontend dependencies and the `Ad` component; adds `services/frontend/CHANGELOG.md` and a root `CHANGELOG.md`.

## Stack
Part of the TRAIN-3546 split. Base: `main`. The healthchecks PR stacks on top of this one.

## How to test
- [ ] `docker compose up` and confirm frontend serves on :3000 with RUM configured.
Note: The prod docker-compose will not work until a release is built (the `latest` image won't have the required `server.js` file until then.)

Made with [Cursor](https://cursor.com)