### PR TITLE
Add dev-to-prod compose transformation tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 - Replaced `wait-for-it`-based startup ordering with container `healthcheck` blocks across all services and `depends_on` `condition: service_healthy`/`service_started` gating in both compose files.
 - Removed the `wait-for-it` package from the backend, ads (Python), and discounts Dockerfiles (adding `netcat-openbsd` where the healthcheck needs `nc`).
 - Backend gains a `.dockerignore`, and `services/backend/config/database.yml` now reads `POSTGRES_USER`/`POSTGRES_PASSWORD` from the environment.
+
+### Compose transformation tooling
+
+- Added `scripts/transform_compose.py` and `scripts/transform_compose_frontend.py` to generate a production compose configuration from the development compose file (image swaps, `development` -> `production` targets, frontend build -> image, comment stripping).
+- Added `unittest`-based coverage in `scripts/test_transform_compose.py` and `scripts/test_transform_compose_frontend.py`.

--- a/scripts/test_transform_compose.py
+++ b/scripts/test_transform_compose.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+Unit tests for transform_compose.py
+
+Run with: python3 -m pytest test_transform_compose.py -v
+Or: python3 test_transform_compose.py
+"""
+
+import unittest
+import tempfile
+import os
+from transform_compose import ComposeTransformer, transform_compose_file, SERVICE_TO_IMAGE_MAP
+
+
+class TestComposeTransformer(unittest.TestCase):
+    """Test cases for the ComposeTransformer class."""
+    
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        self.sample_compose_content = """# Storedog Development Environment
+# This docker-compose file sets up a complete development environment for the Storedog application.
+services:
+  # Datadog Agent for monitoring and observability
+  dd-agent:
+    image: gcr.io/datadoghq/agent:latest
+    pid: host
+    environment:
+      - DD_API_KEY=${DD_API_KEY}
+      - DD_ENV=${DD_ENV:-development}
+      - DD_HOSTNAME=${DD_HOSTNAME-development-host}
+
+  # Frontend service (Next.js)
+  frontend:
+    build:
+      context: ./services/frontend
+      dockerfile: Dockerfile
+      target: development
+      args: 
+        NEXT_PUBLIC_DD_ENV: ${NEXT_PUBLIC_DD_ENV:-development}
+        NEXT_PUBLIC_DD_VERSION_FRONTEND: ${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
+        NEXT_PUBLIC_DD_SERVICE_FRONTEND: ${NEXT_PUBLIC_DD_SERVICE_FRONTEND:-store-frontend}
+        NEXT_PUBLIC_DD_SITE: ${NEXT_PUBLIC_DD_SITE:-datadoghq.com}
+        NEXT_PUBLIC_DD_APPLICATION_ID: ${NEXT_PUBLIC_DD_APPLICATION_ID:-not-set-in-docker-compose}
+        NEXT_PUBLIC_DD_CLIENT_TOKEN: ${NEXT_PUBLIC_DD_CLIENT_TOKEN:-not-set-in-docker-compose}
+    command: ${FRONTEND_COMMAND:-npm run dev}
+    depends_on:
+      dd-agent:
+        condition: service_started
+    environment:
+      - DD_ENV=${DD_ENV:-development}
+      - DD_SERVICE=store-frontend
+
+  # Backend service (Ruby on Rails/Spree)
+  backend:
+    build:
+      context: ./services/backend
+    command: /bin/bash -c "rm -f /app/tmp/pids/server.pid && bundle exec ddprofrb exec rails s -b 0.0.0.0 -p 4000"
+    environment:
+      - DD_ENV=${DD_ENV:-development}
+      - DD_SERVICE=store-backend
+
+  # Background job processor (Sidekiq)
+  worker:
+    build:
+      context: ./services/backend
+    command: bundle exec ddprofrb exec sidekiq -C config/sidekiq.yml
+    environment:
+      - DD_ENV=${DD_ENV:-development}
+      - DD_SERVICE=store-worker
+
+volumes:
+  redis:
+  postgres_logs:
+
+networks:
+  storedog-network:
+"""
+    
+    def test_replace_build_sections(self):
+        """Test that build sections are correctly replaced with image sections."""
+        transformer = ComposeTransformer(self.sample_compose_content)
+        result = transformer.replace_build_sections()
+        
+        content = result.get_content()
+        transformations = result.get_transformations()
+        
+        # Check that build sections are removed
+        self.assertNotIn('build:', content)
+        self.assertNotIn('context:', content)
+        self.assertNotIn('dockerfile:', content)
+        self.assertNotIn('target:', content)
+        self.assertNotIn('args:', content)
+        
+        # Check that image sections are added
+        self.assertIn('image: ghcr.io/datadog/storedog/frontend:${STOREDOG_IMAGE_VERSION:-latest}', content)
+        self.assertIn('image: ghcr.io/datadog/storedog/backend:${STOREDOG_IMAGE_VERSION:-latest}', content)
+        
+        # Check transformations were tracked
+        self.assertIn('Transformed frontend: replaced build with image', transformations)
+        self.assertIn('Transformed backend: replaced build with image', transformations)
+        self.assertIn('Transformed worker: replaced build with image', transformations)
+    
+    def test_update_frontend_command(self):
+        """Test that frontend command is updated from dev to prod."""
+        transformer = ComposeTransformer(self.sample_compose_content)
+        result = transformer.update_frontend_command()
+        
+        content = result.get_content()
+        transformations = result.get_transformations()
+        
+        # Check that command was updated
+        self.assertNotIn('${FRONTEND_COMMAND:-npm run dev}', content)
+        self.assertIn('${FRONTEND_COMMAND:-npm run prod}', content)
+        
+        # Check transformation was tracked
+        self.assertIn('Updated frontend command to use npm run prod', transformations)
+    
+    def test_update_dd_agent_image(self):
+        """Test that dd-agent image is updated to use DD_AGENT_VERSION variable."""
+        transformer = ComposeTransformer(self.sample_compose_content)
+        result = transformer.update_dd_agent_image()
+        
+        content = result.get_content()
+        transformations = result.get_transformations()
+        
+        # Check that image was updated
+        self.assertNotIn('gcr.io/datadoghq/agent:latest', content)
+        self.assertIn('gcr.io/datadoghq/agent:${DD_AGENT_VERSION:-latest}', content)
+        
+        # Check transformation was tracked
+        self.assertIn('Updated dd-agent image to use DD_AGENT_VERSION variable', transformations)
+    
+    def test_remove_header_comments(self):
+        """Test that header comments are removed."""
+        transformer = ComposeTransformer(self.sample_compose_content)
+        result = transformer.remove_header_comments()
+        
+        content = result.get_content()
+        transformations = result.get_transformations()
+        
+        # Check that header comments are removed
+        self.assertNotIn('# Storedog Development Environment', content)
+        self.assertNotIn('# This docker-compose file sets up', content)
+        
+        # Content should start with services:
+        self.assertTrue(content.strip().startswith('services:'))
+        
+        # Check transformation was tracked
+        self.assertIn('Removed header comments', transformations)
+    
+    def test_remove_service_comments(self):
+        """Test that service section comments are removed."""
+        transformer = ComposeTransformer(self.sample_compose_content)
+        result = transformer.remove_service_comments()
+        
+        content = result.get_content()
+        transformations = result.get_transformations()
+        
+        # Check that service comments are removed
+        self.assertNotIn('# Datadog Agent for monitoring', content)
+        self.assertNotIn('# Frontend service (Next.js)', content)
+        self.assertNotIn('# Backend service (Ruby on Rails/Spree)', content)
+        self.assertNotIn('# Background job processor (Sidekiq)', content)
+        
+        # Check transformation was tracked
+        self.assertTrue(any('service section comments' in t for t in transformations))
+    
+    def test_change_development_to_production(self):
+        """Test that development is changed to production."""
+        transformer = ComposeTransformer(self.sample_compose_content)
+        result = transformer.change_development_to_production()
+        
+        content = result.get_content()
+        transformations = result.get_transformations()
+        
+        # Check that specific development values are replaced with production
+        self.assertIn('production', content)
+        self.assertIn('DD_ENV=${DD_ENV:-production}', content)
+        self.assertIn('DD_HOSTNAME=${DD_HOSTNAME-production-host}', content)
+        self.assertIn('target: production', content)
+        
+        # Check that development in comments is preserved (we don't change comments)
+        self.assertIn('# Storedog Development Environment', content)
+        
+        # Check transformation was tracked
+        self.assertTrue(any('development\' to \'production' in t for t in transformations))
+    
+    def test_remove_development_volumes(self):
+        """Test that development volumes are removed from multiple services."""
+        # Create content with volumes to test removal
+        content_with_volumes = """services:
+  frontend:
+    build:
+      context: ./services/frontend
+    volumes:
+      - ./services/frontend:/app
+      - /app/node_modules
+    networks:
+      - storedog-network
+  backend:
+    build:
+      context: ./services/backend
+    volumes:
+      - ./services/backend:/app
+    networks:
+      - storedog-network
+"""
+        transformer = ComposeTransformer(content_with_volumes)
+        result = transformer.remove_development_volumes()
+        
+        content = result.get_content()
+        transformations = result.get_transformations()
+        
+        # Check that volumes sections are removed from development services
+        self.assertNotIn('volumes:', content)
+        
+        # Check transformation was tracked (if volumes were found and removed)
+        if transformations:
+            self.assertTrue(any('development volumes' in t for t in transformations))
+    
+    def test_method_chaining(self):
+        """Test that methods can be chained together."""
+        transformer = ComposeTransformer(self.sample_compose_content)
+        result = (transformer
+                  .replace_build_sections()
+                  .update_frontend_command()
+                  .update_dd_agent_image()
+                  .remove_header_comments()
+                  .remove_service_comments()
+                  .change_development_to_production()
+                  .remove_development_volumes())
+        
+        content = result.get_content()
+        transformations = result.get_transformations()
+        
+        # Check that all transformations were applied
+        self.assertNotIn('build:', content)
+        self.assertNotIn('target:', content)
+        self.assertNotIn('args:', content)
+        self.assertIn('image: ghcr.io/datadog/storedog/frontend:${STOREDOG_IMAGE_VERSION:-latest}', content)
+        self.assertIn('${FRONTEND_COMMAND:-npm run prod}', content)
+        self.assertIn('gcr.io/datadoghq/agent:${DD_AGENT_VERSION:-latest}', content)
+        self.assertTrue(content.strip().startswith('services:'))
+        self.assertIn('production', content)
+        # Check specific transformations but allow development in comments
+        self.assertIn('DD_ENV=${DD_ENV:-production}', content)
+        
+        # Check that multiple transformations were tracked
+        self.assertGreater(len(transformations), 5)
+    
+    def test_no_transformations_when_patterns_not_found(self):
+        """Test that no transformations are applied when patterns are not found."""
+        simple_content = """services:
+  redis:
+    image: redis:6.2-alpine
+"""
+        transformer = ComposeTransformer(simple_content)
+        result = (transformer
+                  .replace_build_sections()
+                  .update_frontend_command()
+                  .update_dd_agent_image())
+        
+        transformations = result.get_transformations()
+        
+        # No transformations should be applied
+        self.assertEqual(len(transformations), 0)
+        
+        # Content should remain unchanged
+        self.assertEqual(result.get_content(), simple_content)
+
+
+class TestTransformComposeFile(unittest.TestCase):
+    """Test cases for the transform_compose_file function."""
+    
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        self.sample_content = """# Header comment
+# Another header comment
+services:
+  frontend:
+    build:
+      context: ./services/frontend
+      dockerfile: Dockerfile
+      target: development
+      args: 
+        NEXT_PUBLIC_DD_ENV: ${NEXT_PUBLIC_DD_ENV:-development}
+        NEXT_PUBLIC_DD_VERSION_FRONTEND: ${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
+    command: ${FRONTEND_COMMAND:-npm run dev}
+  dd-agent:
+    image: gcr.io/datadoghq/agent:latest
+    environment:
+      - DD_ENV=${DD_ENV:-development}
+"""
+    
+    def test_transform_compose_file_success(self):
+        """Test successful transformation of a compose file."""
+        # Create temporary input file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write(self.sample_content)
+            input_file = f.name
+        
+        # Create temporary output file
+        with tempfile.NamedTemporaryFile(suffix='.yml', delete=False) as f:
+            output_file = f.name
+        
+        try:
+            # Transform the file
+            result = transform_compose_file(input_file, output_file)
+            self.assertTrue(result)
+            
+            # Check that output file was created and contains expected content
+            self.assertTrue(os.path.exists(output_file))
+            
+            with open(output_file, 'r') as f:
+                output_content = f.read()
+            
+            # Verify transformations
+            self.assertIn('image: ghcr.io/datadog/storedog/frontend:${STOREDOG_IMAGE_VERSION:-latest}', output_content)
+            self.assertIn('${FRONTEND_COMMAND:-npm run prod}', output_content)
+            self.assertIn('gcr.io/datadoghq/agent:${DD_AGENT_VERSION:-latest}', output_content)
+            self.assertNotIn('# Header comment', output_content)
+            self.assertNotIn('development', output_content)
+            self.assertIn('production', output_content)
+            
+        finally:
+            # Clean up temporary files
+            os.unlink(input_file)
+            os.unlink(output_file)
+    
+    def test_transform_compose_file_nonexistent_input(self):
+        """Test handling of nonexistent input file."""
+        result = transform_compose_file('nonexistent_file.yml')
+        self.assertFalse(result)
+    
+    def test_default_output_filename(self):
+        """Test that default output filename is generated correctly."""
+        # Create temporary input file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write(self.sample_content)
+            input_file = f.name
+        
+        try:
+            # Transform without specifying output file
+            result = transform_compose_file(input_file)
+            self.assertTrue(result)
+            
+            # Check that default output file was created
+            expected_output = input_file.replace('.yml', '.prod.yml')
+            self.assertTrue(os.path.exists(expected_output))
+            
+            # Clean up
+            os.unlink(expected_output)
+            
+        finally:
+            os.unlink(input_file)
+
+
+class TestServiceToImageMap(unittest.TestCase):
+    """Test cases for the SERVICE_TO_IMAGE_MAP configuration."""
+    
+    def test_service_to_image_map_completeness(self):
+        """Test that all expected services are in the mapping."""
+        expected_services = {
+            'frontend', 'backend', 'worker', 'discounts', 
+            'ads', 'service-proxy', 'postgres', 'puppeteer'
+        }
+        
+        actual_services = set(SERVICE_TO_IMAGE_MAP.keys())
+        self.assertEqual(expected_services, actual_services)
+    
+    def test_worker_uses_backend_image(self):
+        """Test that worker service uses the same image as backend."""
+        self.assertEqual(
+            SERVICE_TO_IMAGE_MAP['worker'],
+            SERVICE_TO_IMAGE_MAP['backend']
+        )
+    
+    def test_all_images_use_storedog_image_version(self):
+        """Test that all images use the STOREDOG_IMAGE_VERSION variable."""
+        for service, image in SERVICE_TO_IMAGE_MAP.items():
+            self.assertIn('${STOREDOG_IMAGE_VERSION:-latest}', image)
+            self.assertIn('ghcr.io/datadog/storedog/', image)
+
+
+if __name__ == '__main__':
+    # Run the tests
+    unittest.main(verbosity=2)

--- a/scripts/test_transform_compose_frontend.py
+++ b/scripts/test_transform_compose_frontend.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Unit tests for transform_compose_frontend.py
+
+Run with: python3 test_transform_compose_frontend.py
+"""
+
+import unittest
+import tempfile
+import os
+from transform_compose_frontend import FrontendComposeTransformer, transform_compose_file
+
+
+class TestFrontendTransformer(unittest.TestCase):
+    """Test the frontend transformer functionality."""
+    
+    def test_removes_volumes_and_changes_target(self):
+        """Test that volumes are removed and target is changed to production."""
+        content = """services:
+  frontend:
+    build:
+      context: ./services/frontend
+      target: development
+    volumes:
+      - ./services/frontend:/app
+      - /app/node_modules
+    ports:
+      - '3000:3000'
+  backend:
+    volumes:
+      - ./services/backend:/app
+"""
+        
+        transformer = FrontendComposeTransformer(content)
+        result = transformer.remove_frontend_volumes().change_frontend_target_to_production()
+        
+        output = result.get_content()
+        transformations = result.get_transformations()
+        
+        # Check transformations were applied
+        self.assertEqual(len(transformations), 2)
+        self.assertIn("Removed volumes from frontend service", transformations)
+        self.assertIn("Changed frontend build target to production", transformations)
+        
+        # Check output
+        self.assertIn("target: production", output)
+        self.assertNotIn("target: development", output)
+        self.assertNotIn("- ./services/frontend:/app", output)
+        self.assertIn("- ./services/backend:/app", output)  # Backend volumes should remain
+    
+    def test_no_changes_when_already_production(self):
+        """Test no changes when frontend is already configured for production."""
+        content = """services:
+  frontend:
+    build:
+      target: production
+    ports:
+      - '3000:3000'
+"""
+        
+        transformer = FrontendComposeTransformer(content)
+        result = transformer.remove_frontend_volumes().change_frontend_target_to_production()
+        
+        # Should be no transformations
+        self.assertEqual(len(result.get_transformations()), 0)
+        self.assertEqual(result.get_content(), content)
+    
+    def test_no_changes_when_no_frontend_service(self):
+        """Test no changes when there's no frontend service."""
+        content = """services:
+  backend:
+    build:
+      context: ./services/backend
+    volumes:
+      - ./services/backend:/app
+"""
+        
+        transformer = FrontendComposeTransformer(content)
+        result = transformer.remove_frontend_volumes().change_frontend_target_to_production()
+        
+        # Should be no transformations
+        self.assertEqual(len(result.get_transformations()), 0)
+        self.assertEqual(result.get_content(), content)
+
+
+class TestTransformFile(unittest.TestCase):
+    """Test the file transformation functionality."""
+    
+    def test_transform_file_success(self):
+        """Test successful file transformation."""
+        content = """services:
+  frontend:
+    build:
+      context: ./services/frontend
+      target: development
+    volumes:
+      - ./services/frontend:/app
+    ports:
+      - '3000:3000'
+"""
+        
+        # Create temporary files
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as input_f:
+            input_f.write(content)
+            input_file = input_f.name
+        
+        with tempfile.NamedTemporaryFile(suffix='.yml', delete=False) as output_f:
+            output_file = output_f.name
+        
+        try:
+            # Transform the file
+            result = transform_compose_file(input_file, output_file)
+            self.assertTrue(result)
+            
+            # Check output file
+            with open(output_file, 'r') as f:
+                output_content = f.read()
+            
+            self.assertIn("target: production", output_content)
+            self.assertNotIn("volumes:", output_content)
+            
+        finally:
+            os.unlink(input_file)
+            os.unlink(output_file)
+    
+    def test_nonexistent_input_file(self):
+        """Test handling of nonexistent input file."""
+        result = transform_compose_file('nonexistent.yml')
+        self.assertFalse(result)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/scripts/transform_compose.py
+++ b/scripts/transform_compose.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+Script to transform docker-compose.dev.yml by:
+1. Replacing build.context sections with ghcr.io image references
+2. Changing frontend command from npm run dev to npm run prod
+3. Updating dd-agent image to use DD_AGENT_VERSION variable
+4. Removing comments
+5. Changing "development" to "production"
+"""
+
+import sys
+import os
+import re
+from typing import List
+
+# Configuration
+SERVICE_TO_IMAGE_MAP = {
+    'frontend': 'ghcr.io/datadog/storedog/frontend:${STOREDOG_IMAGE_VERSION:-latest}',
+    'backend': 'ghcr.io/datadog/storedog/backend:${STOREDOG_IMAGE_VERSION:-latest}',
+    'worker': 'ghcr.io/datadog/storedog/backend:${STOREDOG_IMAGE_VERSION:-latest}',  # worker uses same image as backend
+    'discounts': 'ghcr.io/datadog/storedog/discounts:${STOREDOG_IMAGE_VERSION:-latest}',
+    'ads': 'ghcr.io/datadog/storedog/ads-java:${STOREDOG_IMAGE_VERSION:-latest}',
+    'service-proxy': 'ghcr.io/datadog/storedog/nginx:${STOREDOG_IMAGE_VERSION:-latest}',
+    'postgres': 'ghcr.io/datadog/storedog/postgres:${STOREDOG_IMAGE_VERSION:-latest}',
+    'puppeteer': 'ghcr.io/datadog/storedog/puppeteer:${STOREDOG_IMAGE_VERSION:-latest}'
+}
+
+class ComposeTransformer:
+    """Handles transformation of Docker Compose files."""
+    
+    def __init__(self, content: str):
+        self.content = content
+        self.transformations_applied = []
+    
+    def apply_regex_transformation(self, pattern: str, replacement: str, description: str, flags: int = re.MULTILINE) -> 'ComposeTransformer':
+        """Apply a regex transformation and track what was changed."""
+        if re.search(pattern, self.content, flags=flags):
+            self.content = re.sub(pattern, replacement, self.content, flags=flags)
+            self.transformations_applied.append(description)
+        return self
+    
+    def replace_build_sections(self) -> 'ComposeTransformer':
+        """Replace build sections with image sections for all configured services."""
+        for service_name, image_name in SERVICE_TO_IMAGE_MAP.items():
+            # Simple and reliable approach: find service definition and replace its build section
+            # Match service at top level (2 spaces), then find its build section
+            service_pattern = rf'^  {re.escape(service_name)}:\s*$'
+            
+            if re.search(service_pattern, self.content, flags=re.MULTILINE):
+                # Find and replace the build section for this specific service
+                build_pattern = rf'^(  {re.escape(service_name)}:\s*\n(?:(?!^    build:).*\n)*?)    build:\s*\n(?:      .*\n)*?(?=^    [a-zA-Z0-9_-]+:|^  [a-zA-Z0-9_-]+:|^[a-zA-Z]|$)'
+                replacement = rf'\1    image: {image_name}\n'
+                
+                if re.search(build_pattern, self.content, flags=re.MULTILINE):
+                    self.content = re.sub(build_pattern, replacement, self.content, flags=re.MULTILINE)
+                    self.transformations_applied.append(f"Transformed {service_name}: replaced build with image")
+        
+        return self
+    
+    
+    def update_frontend_command(self) -> 'ComposeTransformer':
+        """Update frontend command from npm run dev to npm run prod."""
+        pattern = r'(\s+frontend:\s*\n(?:.*\n)*?\s+command:\s+)\${FRONTEND_COMMAND:-npm run dev}'
+        replacement = r'\1${FRONTEND_COMMAND:-npm run prod}'
+        return self.apply_regex_transformation(
+            pattern, replacement, "Updated frontend command to use npm run prod"
+        )
+    
+    def update_dd_agent_image(self) -> 'ComposeTransformer':
+        """Update dd-agent image to use DD_AGENT_VERSION variable."""
+        pattern = r'(\s+dd-agent:\s*\n\s+image:\s+)gcr\.io/datadoghq/agent:[^\n]+'
+        replacement = r'\1gcr.io/datadoghq/agent:${DD_AGENT_VERSION:-latest}'
+        return self.apply_regex_transformation(
+            pattern, replacement, "Updated dd-agent image to use DD_AGENT_VERSION variable"
+        )
+    
+    def remove_header_comments(self) -> 'ComposeTransformer':
+        """Remove header comments at the top of the file."""
+        pattern = r'^# [^\n]*\n# [^\n]*\n'
+        replacement = ''
+        return self.apply_regex_transformation(
+            pattern, replacement, "Removed header comments"
+        )
+    
+    def remove_service_comments(self) -> 'ComposeTransformer':
+        """Remove comments that appear directly before service definitions."""
+        pattern = r'\n\s*# [^\n]*\n(\s+[a-zA-Z0-9_-]+:\s*\n)'
+        matches = re.findall(pattern, self.content, flags=re.MULTILINE)
+        if matches:
+            self.content = re.sub(pattern, r'\n\1', self.content, flags=re.MULTILINE)
+            self.transformations_applied.append(f"Removed {len(matches)} service section comments")
+        return self
+    
+    def change_development_to_production(self) -> 'ComposeTransformer':
+        """Change default values from 'development' to 'production' but preserve variable names."""
+        total_changes = 0
+        
+        # Change 'development' when it appears as a default value (after :- )
+        pattern = r'(:-\s*)development(\s*[}\)])'
+        matches = len(re.findall(pattern, self.content))
+        if matches > 0:
+            self.content = re.sub(pattern, r'\1production\2', self.content)
+            total_changes += matches
+        
+        # Change RAILS_ENV=development to RAILS_ENV=production
+        rails_pattern = r'(RAILS_ENV=)development'
+        if re.search(rails_pattern, self.content):
+            self.content = re.sub(rails_pattern, r'\1production', self.content)
+            total_changes += 1
+            
+        # Change hostname default values like ${DD_HOSTNAME-development-host}
+        hostname_pattern = r'(\$\{DD_HOSTNAME-)development(-[^}]+\})'
+        hostname_matches = len(re.findall(hostname_pattern, self.content))
+        if hostname_matches > 0:
+            self.content = re.sub(hostname_pattern, r'\1production\2', self.content)
+            total_changes += hostname_matches
+            
+        # Change target: development to target: production (for build contexts)
+        target_pattern = r'(\s+target:\s+)development'
+        target_matches = len(re.findall(target_pattern, self.content))
+        if target_matches > 0:
+            self.content = re.sub(target_pattern, r'\1production', self.content)
+            total_changes += target_matches
+            
+        if total_changes > 0:
+            self.transformations_applied.append(f"Changed {total_changes} instances of 'development' to 'production'")
+            
+        return self
+    
+    def remove_development_volumes(self) -> 'ComposeTransformer':
+        """Remove development volume mounts from services (but keep essential volumes)."""
+        # Remove volumes sections from specific services, but preserve dd-agent, postgres, and redis volumes
+        patterns_to_remove = [
+            # Frontend volumes
+            r'(\s+frontend:\s*\n(?:.*\n)*?)\s+volumes:\s*\n(?:\s+-[^\n]*\n)+(?=\s+[a-zA-Z0-9_-]+:)',
+            # Backend volumes  
+            r'(\s+backend:\s*\n(?:.*\n)*?)\s+volumes:\s*\n(?:\s+-[^\n]*\n)+(?=\s+[a-zA-Z0-9_-]+:)',
+            # Worker volumes
+            r'(\s+worker:\s*\n(?:.*\n)*?)\s+volumes:\s*\n(?:\s+-[^\n]*\n)+(?=\s+[a-zA-Z0-9_-]+:)',
+            # Discounts volumes
+            r'(\s+discounts:\s*\n(?:.*\n)*?)\s+volumes:\s*\n(?:\s+-[^\n]*\n)+(?=\s+[a-zA-Z0-9_-]+:)',
+            # Puppeteer volumes
+            r'(\s+puppeteer:\s*\n(?:.*\n)*?)\s+volumes:\s*\n(?:\s+-[^\n]*\n)+(?=\s+[a-zA-Z0-9_-]+:|^volumes:)'
+        ]
+        
+        removed_count = 0
+        for pattern in patterns_to_remove:
+            if re.search(pattern, self.content, flags=re.MULTILINE):
+                self.content = re.sub(pattern, r'\1', self.content, flags=re.MULTILINE)
+                removed_count += 1
+        
+        if removed_count > 0:
+            self.transformations_applied.append(f"Removed development volumes from {removed_count} services")
+        return self
+    
+    
+    def get_content(self) -> str:
+        """Get the transformed content."""
+        return self.content
+    
+    def get_transformations(self) -> List[str]:
+        """Get list of transformations that were applied."""
+        return self.transformations_applied
+
+def transform_compose_file(input_file: str, output_file: str = None) -> bool:
+    """
+    Transform docker-compose.dev.yml file by making only the specified changes
+    and preserving all other formatting and structure.
+    """
+    
+    # Read the input file
+    try:
+        with open(input_file, 'r') as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"Error: Input file '{input_file}' not found!")
+        return False
+    except Exception as e:
+        print(f"Error reading file: {e}")
+        return False
+    
+    # Apply all transformations using the transformer class
+    transformer = (ComposeTransformer(content)
+                   .replace_build_sections()
+                   .update_frontend_command()
+                   .update_dd_agent_image()
+                   .remove_header_comments()
+                   .remove_service_comments()
+                   .change_development_to_production()
+                   .remove_development_volumes())
+    
+    # Print what was transformed
+    for transformation in transformer.get_transformations():
+        print(transformation)
+    
+    # Determine output file
+    if output_file is None:
+        output_file = input_file.replace('.yml', '.prod.yml')
+    
+    # Write the transformed content
+    try:
+        with open(output_file, 'w') as f:
+            f.write(transformer.get_content())
+        print(f"Transformation complete! Output written to: {output_file}")
+        
+        return True
+    except Exception as e:
+        print(f"Error writing file: {e}")
+        return False
+
+def main() -> int:
+    """Main function to handle command line arguments and execute transformation."""
+    
+    # Default input file
+    input_file = "docker-compose.dev.yml"
+    output_file = None
+    
+    # Parse command line arguments
+    if len(sys.argv) > 1:
+        input_file = sys.argv[1]
+    if len(sys.argv) > 2:
+        output_file = sys.argv[2]
+    
+    # Check if input file exists
+    if not os.path.exists(input_file):
+        print(f"Error: Input file '{input_file}' not found!")
+        print(f"Usage: {sys.argv[0]} [input_file] [output_file]")
+        return 1
+    
+    # Perform transformation
+    success = transform_compose_file(input_file, output_file)
+    
+    return 0 if success else 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/transform_compose_frontend.py
+++ b/scripts/transform_compose_frontend.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Script to transform docker-compose.dev.yml by modifying only the frontend service:
+1. Remove volumes from frontend service
+2. Change frontend build target from development to production
+"""
+
+import sys
+import os
+import re
+from typing import List
+
+class FrontendComposeTransformer:
+    """Handles transformation of Docker Compose files for frontend service only."""
+    
+    def __init__(self, content: str):
+        self.content = content
+        self.transformations_applied = []
+    
+    def apply_regex_transformation(self, pattern: str, replacement: str, description: str, flags: int = re.MULTILINE) -> 'FrontendComposeTransformer':
+        """Apply a regex transformation and track what was changed."""
+        if re.search(pattern, self.content, flags=flags):
+            self.content = re.sub(pattern, replacement, self.content, flags=flags)
+            self.transformations_applied.append(description)
+        return self
+    
+    def remove_frontend_volumes(self) -> 'FrontendComposeTransformer':
+        """Remove volumes section from frontend service only."""
+        # Pattern to match frontend service volumes section
+        pattern = r'(\s+frontend:\s*\n(?:.*\n)*?)\s+volumes:\s*\n(?:\s+-[^\n]*\n)+(\s+(?:[a-zA-Z0-9_-]+:|$))'
+        replacement = r'\1\2'
+        
+        return self.apply_regex_transformation(
+            pattern, replacement, "Removed volumes from frontend service"
+        )
+    
+    def change_frontend_target_to_production(self) -> 'FrontendComposeTransformer':
+        """Change frontend build target from development to production."""
+        # Pattern to match frontend service build target that is NOT already production
+        pattern = r'(\s+frontend:\s*\n(?:.*\n)*?\s+build:\s*\n(?:.*\n)*?\s+target:\s+)(?!production\b)(\S+)'
+        replacement = r'\1production'
+        
+        return self.apply_regex_transformation(
+            pattern, replacement, "Changed frontend build target to production"
+        )
+    
+    def get_content(self) -> str:
+        """Get the transformed content."""
+        return self.content
+    
+    def get_transformations(self) -> List[str]:
+        """Get list of transformations that were applied."""
+        return self.transformations_applied
+
+def transform_compose_file(input_file: str, output_file: str = None) -> bool:
+    """
+    Transform docker-compose.dev.yml file by modifying only the frontend service
+    to remove volumes and change target to production.
+    """
+    
+    # Read the input file
+    try:
+        with open(input_file, 'r') as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"Error: Input file '{input_file}' not found!")
+        return False
+    except Exception as e:
+        print(f"Error reading file: {e}")
+        return False
+    
+    # Apply frontend-specific transformations
+    transformer = (FrontendComposeTransformer(content)
+                   .remove_frontend_volumes()
+                   .change_frontend_target_to_production())
+    
+    # Print what was transformed
+    transformations = transformer.get_transformations()
+    if transformations:
+        for transformation in transformations:
+            print(transformation)
+    else:
+        print("No transformations were applied - frontend service may already be configured correctly")
+    
+    # Determine output file
+    if output_file is None:
+        output_file = input_file.replace('.yml', '.frontend-prod.yml')
+    
+    # Write the transformed content
+    try:
+        with open(output_file, 'w') as f:
+            f.write(transformer.get_content())
+        print(f"Transformation complete! Output written to: {output_file}")
+        
+        return True
+    except Exception as e:
+        print(f"Error writing file: {e}")
+        return False
+
+def main() -> int:
+    """Main function to handle command line arguments and execute transformation."""
+    
+    # Default input file
+    input_file = "docker-compose.dev.yml"
+    output_file = None
+    
+    # Parse command line arguments
+    if len(sys.argv) > 1:
+        input_file = sys.argv[1]
+    if len(sys.argv) > 2:
+        output_file = sys.argv[2]
+    
+    # Check if input file exists
+    if not os.path.exists(input_file):
+        print(f"Error: Input file '{input_file}' not found!")
+        print(f"Usage: {sys.argv[0]} [input_file] [output_file]")
+        return 1
+    
+    # Perform transformation
+    success = transform_compose_file(input_file, output_file)
+    
+    return 0 if success else 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/transform_compose.py` and `scripts/transform_compose_frontend.py` to generate a production docker-compose configuration from the dev file (image swaps, `development` -> `production` targets, frontend build -> image, comment stripping).
- Adds `unittest` coverage in `scripts/test_transform_compose.py` and `scripts/test_transform_compose_frontend.py` (20 tests).

## Stack
Part of the TRAIN-3546 split. **Base: `TRAIN-3546-docker-compose-healthchecks`** (tooling targets the finalized compose structure). Merge after #184.

## Test plan
- [ ] `cd scripts && python3 -m unittest test_transform_compose test_transform_compose_frontend`

Made with [Cursor](https://cursor.com)