### PR TITLE
Refactor Makefile, restructure docs, and bump backend gems

### DIFF
--- a/.env.development.template
+++ b/.env.development.template
@@ -1,0 +1,6 @@
+# For local development, set these manually using a trial or dogfood account
+
+DD_API_KEY=
+DD_APP_KEY=
+NEXT_PUBLIC_DD_APPLICATION_ID= # Only needed if using RUM
+NEXT_PUBLIC_DD_CLIENT_TOKEN= # Only needed if using RUM

--- a/.env.template
+++ b/.env.template
@@ -12,18 +12,23 @@ NEXT_PUBLIC_DD_CLIENT_TOKEN=   # Required for RUM in frontend service
 # =============================================
 DD_ENV=development # usually set to some form of identifier of what the course/lab is (such as `dd101-sre`) 
 DD_HOSTNAME=development-host # usually set to the DD_ENV with `-host` appended
-NEXT_PUBLIC_DD_ENV=development # Required for RUM in frontend service
-NEXT_PUBLIC_DD_SITE=datadoghq.com # Required for RUM in frontend service
+
+DD_LOGS_INJECTION=true #Enable log injection into traces. Some languages' trace libraries turn this on by default, but we turn it on explicitly to prevent confusion.
+DD_PROFILING_ENABLED=true #Enable the Continuous Profiler
+DD_RUNTIME_METRICS_ENABLED=true #Enable runtime metrics
 
 # =============================================
 # Service Versions
-# Follow Storedog releases except Redis (https://github.com/DataDog/storedog/releases)
+# The Agent uses these values to set the `version:` tag for each service.
+# The postgres and redis services come from the actual postgres/redis version.
 # =============================================
+#
+# If you're re-deploying a service in a lab, it may be helpful for you/the learner to update the version number.
+
 NEXT_PUBLIC_DD_VERSION_FRONTEND=1.0.0 # use NEXT_PUBLIC_* to expose var to store frontend
 DD_VERSION_BACKEND=1.0.0 # Use for worker service as well, since they use the same Docker image
 DD_VERSION_DBM=1.0.0
 DD_VERSION_ADS=1.0.0
-DD_VERSION_ADS_PYTHON=1.0.0
 DD_VERSION_DISCOUNTS=1.0.0
 DD_VERSION_POSTGRES=15.0
 DD_VERSION_NGINX=1.28.0
@@ -40,8 +45,15 @@ DB_POOL=25 # Database connection pool size set in backend service (default: 25)
 MAX_THREADS=5 # Maximum number of concurrent threads set in backend service (default: 5)
 
 # =============================================
-# Nginx/Service Proxy Configuration
+# A/B testing Ads services
 # =============================================
+
+# ads-python service
+
+DD_VERSION_ADS_PYTHON=1.0.0
+
+# Nginx/Service Proxy Configuration
+
 ADS_A_UPSTREAM=ads:3030
 ADS_B_UPSTREAM=ads-python:3030
 ADS_B_PERCENT=0 # Set < 0 > 100 to split traffic between ads services
@@ -49,12 +61,19 @@ ADS_B_PERCENT=0 # Set < 0 > 100 to split traffic between ads services
 # =============================================
 # Frontend Service Configuration
 # =============================================
-NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend # Service name for frontend service in Datadog
+
+NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend # RUM SDK uses this to set the `service:` tag for RUM data
+NEXT_PUBLIC_DD_SITE=datadoghq.com # Datadog site. Used in RUM SDK init()
+NEXT_PUBLIC_DD_ENV=development # Required for RUM SDK
+
 NEXT_PUBLIC_FRONTEND_API_ROUTE=http://service-proxy:80 # base url for next.js API routes (default: 'http://service-proxy:80')
 NEXT_PUBLIC_SPREE_API_HOST=http://service-proxy/services/backend # base url for backend service (default: 'http://service-proxy/services/backend')
+
+# The values without the `http://service-proxy` prefix are used in the frontend service's `fetch` calls, which are made from the browser and are caught by the nginx service, because it intercepts calls to Next.js API routes and routes them to the appropriate service.
+
 NEXT_PUBLIC_SPREE_CLIENT_HOST=/services/backend # base url for backend service (default: '/services/backend')
 NEXT_PUBLIC_SPREE_IMAGE_HOST=/services/backend # base url for backend service (default: '/services/backend')
-NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN=service-proxy # allowed image domain for backend service (default: 'service-proxy')
+NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN=service-proxy # allowed image domain (default: 'service-proxy')
 NEXT_PUBLIC_ADS_ROUTE=/services/ads # base url for ads service (default: '/services/ads')
 NEXT_PUBLIC_DISCOUNTS_ROUTE=/services/discounts # base url for discounts service (default: '/services/discounts')
 NEXT_PUBLIC_DBM_ROUTE=/services/dbm # base url for dbm service (default: '/services/dbm')
@@ -70,6 +89,19 @@ DISABLE_SPRING=1
 # Puppeteer Configuration
 # =============================================
 STOREDOG_URL=http://service-proxy:80 # base url for storedog service (default: 'http://service-proxy:80')
-PUPPETEER_TIMEOUT=30000 # timeout for puppeteer (default: 30000)
 
-SKIP_SESSION_CLOSE= # skip session close for puppeteer (default: ''). Note that the current puppeteer script doesn't make use of this environment variable but can easily be updated to do so
+# In a lab environment, use the lab host's URL instead of service-proxy. See a template course for an example.
+
+PUPPETEER_TIMEOUT=30000 # timeout for puppeteer (default: 30000)
+PUPPETEER_ENABLE_CACHE=false
+PUPPETEER_SYSTEM_MEMORY=8GB # options: 8GB, 16GB, 32GB - sets concurrency defaults
+PUPPETEER_STARTUP_DELAY=10000 # delay in ms before starting sessions
+PUPPETEER_RAMP_INTERVAL=30000 # time in ms between concurrency increases
+PUPPETEER_DEBUG=false
+PUPPETEER_DEBUG_SESSIONS=false
+PUPPETEER_LOOP=infinite # 'infinite' or 'single'
+PUPPETEER_SESSION_TYPES=browsing,vip,frustration,homepage,short,taxonomy
+
+# Optional overrides (defaults derived from PUPPETEER_SYSTEM_MEMORY profile):
+# PUPPETEER_MAX_CONCURRENT=
+# PUPPETEER_BROWSER_POOL_SIZE=

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .pt
 .ruby-gemset
 .env
+
 **/.DS_Store
 
 __pycache__
@@ -28,18 +29,16 @@ config/initializers/secret_token.rb
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
-node_modules/*
+node_modules
 public/sitemap*
 # React on Rails
 npm-debug.log
 npm-debug.log*
-node_modules
 
 # Generated js bundles
 /app/assets/webpack/
 /public/packs
 /public/packs-test
-/node_modules
 yarn-debug.log*
 .yarn-integrity
 /yarn-error.log
@@ -47,8 +46,13 @@ yarn-debug.log*
 !/app/assets/builds/.keep
 
 # local env files
-.env
 .env.development.local
 .env.test.local
 .env.production.local
 .env.local
+
+.gradle/
+
+settings.json
+
+docker-compose.dev.frontend-prod.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 
 - Added `scripts/transform_compose.py` and `scripts/transform_compose_frontend.py` to generate a production compose configuration from the development compose file (image swaps, `development` -> `production` targets, frontend build -> image, comment stripping).
 - Added `unittest`-based coverage in `scripts/test_transform_compose.py` and `scripts/test_transform_compose_frontend.py`.
+
+### Makefile and documentation
+
+- Refactored the `Makefile`: ENV-based selection of the compose file, `prepare-release` and no-cache build targets, and improved help output (wired to the compose transformation scripts).
+- Restructured docs: trimmed the root `README.md`, moved feature descriptions into `FEATURES.md`, and added/updated per-service READMEs (`ads`, `backend`, `discounts`, new `nginx`, new `postgres`).
+- Reworked `.env.template` and added `.env.development.template` for faster local setup; tidied `.gitignore`.
+- Bumped backend gems in `Gemfile.lock` (`datadog-ruby_core_source`, `libddwaf`).

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,168 @@
+
+# Optional Features
+
+This doc covers the different features you can enable in Storedog.
+
+Click on a feature below to learn more.
+
+- [A/B Testing Ads services](#ab-testing-ads-services)
+  - [With Docker Compose](#with-docker-compose)
+  - [With Kubernetes](#with-kubernetes)
+- [Feature flags](#feature-flags)
+  - [DBM](#dbm)
+  - [Error Tracking](#error-tracking)
+  - [Random frontend API errors](#random-frontend-api-errors)
+  - [Frustration Signals in RUM](#frustration-signals-in-rum)
+
+## A/B Testing Ads services
+
+Run two Ads services and split traffic between them. The amount of traffic sent to each service is set with a percent value.
+
+This requires running a second Ads service in addition to the default Java Ads service and setting environment variables in the `service-proxy` service. The Python Ads service is typically used as the secondary service.
+
+### With Docker Compose
+
+1. Set the following environment variables:
+
+    - `DD_VERSION_ADS_PYTHON`: The version number that the Datadog Agent uses to tag the `ads-python` service.
+    - `ADS_A_UPSTREAM`: Host and port for the primary (A) ads service (default: `ads:3030`)
+    - `ADS_B_UPSTREAM`: Host and port for the secondary (B) ads service (default: `ads-python:3030`)
+    - `ADS_B_PERCENT`: Percentage of traffic to route to the B (Python) ads service (default: `0`). The remainder goes to the A ads (Java) service.
+      - Set a value between `0` and `100` to control the split.
+
+    > [!IMPORTANT]
+    >
+    > When `ADS_B_PERCENT` is greater than zero, the `ADS_B_UPSTREAM` endpoint must be reachable. Otherwise, the `service-proxy` will crash and restart.
+
+1. Add a second Ads service to the `docker-compose.yml` or `docker-compose.dev.yml`.
+
+    ```yaml
+      ads-python:
+        image: ghcr.io/datadog/storedog/ads-python:${STOREDOG_IMAGE_VERSION:-latest}
+        build: # Only used if building from source in development
+          context: ./services/ads/python
+        depends_on:
+          - postgres
+          - dd-agent
+        environment:
+          - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+          - POSTGRES_USER=${POSTGRES_USER:-postgres}
+          - POSTGRES_HOST=postgres
+          - DD_AGENT_HOST=dd-agent
+          - DD_ENV=${DD_ENV:-production}
+          - DD_SERVICE=store-ads-python
+          - DD_VERSION=${DD_VERSION_ADS_PYTHON:-1.0.0}
+          - DD_PROFILING_ENABLED=true
+          - DD_PROFILING_TIMELINE_ENABLED=true
+          - DD_PROFILING_ALLOCATION_ENABLED=true
+        volumes: # Only used in development
+          - ./services/ads/python:/app
+        networks:
+          - storedog-network
+        labels:
+          com.datadoghq.ad.logs: '[{"source": "python"}]'
+    ```
+
+1. Add these environment variables to the `service-proxy` service in the `docker-compose.yml` (or `docker-compose.dev.yml`) file:
+
+    ```yaml
+    environment:
+      - ADS_A_UPSTREAM=${ADS_A_UPSTREAM:-ads:3030}
+      - ADS_B_UPSTREAM=${ADS_B_UPSTREAM:-ads-python:3030}
+      - ADS_B_PERCENT=${ADS_B_PERCENT:-0}
+    ```
+
+1. Start the app via `make dev` or `make prod`.
+
+### With Kubernetes
+
+A Kubernetes manifest for the Python Ads service is available in the `services/ads/k8s-manifests/` directory.
+
+1. Add the `ads-python.yaml` file to the `k8s-manifests/storedog-app/deployments/` directory.
+
+1. Add the following environment variables to the `nginx.yaml` file and adjust as needed:
+
+    ```yaml
+    # A/B testing ads services
+    - name: ADS_A_UPSTREAM
+      value: "ads:3030"
+    - name: ADS_B_UPSTREAM
+      value: "ads-python:3030"
+    - name: ADS_B_PERCENT
+      value: "50"
+    ```
+
+1. Follow the instructions in the [Kubernetes README](./k8s-manifests/README.md) to run Storedog in Kubernetes.
+
+1. If the Storedog is already running, apply the manifests to the cluster:
+
+    ```bash
+    envsubst < k8s-manifests/storedog-app/deployments/ads-python.yaml | kubectl apply -n storedog -f -
+    envsubst < k8s-manifests/storedog-app/deployments/nginx.yaml | kubectl apply -n storedog -f -
+    ```
+
+> [!IMPORTANT]
+> Be sure to set the `DD_VERSION_ADS_PYTHON` environment variable so that it will be applied to the file by `envsubst`.
+
+## Feature flags
+
+Some capabilities are hidden behind feature flags, which can be controlled via `services/frontend/site/featureFlags.config.json`.
+
+> [!NOTE]
+> Feature flags are available by default when running the application in development mode. If running in production, you'll need update the file and mount it into the frontend service container in the `docker-compose.yml` file.
+>
+> ```yaml
+> volumes:
+>   - ./services/frontend/site/featureFlags.config.json:/app/featureFlags.config.json
+> ```
+
+### DBM
+
+The `dbm` feature flag enables a product ticker on the homepage with a long-running query to demonstrate DBM.
+
+**How to use**:
+
+1. First, set up the DBM service as described in the [DBM README](./services/dbm/README.md)
+1. Start the app via `docker compose up`
+1. Set the `dbm` feature flag to true
+1. Visit http://localhost and reload the home page a few times
+1. The ticker will appear after 5 seconds and will subsequently update every 5 seconds with a new product and amount ordered
+
+You can modify the ticker functionality in `services/frontend/components/common/NavBar.tsx`.
+
+### Error Tracking
+
+The `error-tracking` feature flag demonstrates Error Tracking. When enabled, the `ads` service experiences exceptions due to unexpected header values.
+
+**How to use**:
+
+1. Start the app via `docker compose up`
+1. Set the `error-tracking` feature flag to `true`
+1. Visit `http://localhost` and reload the home page a few times
+1. 500 errors are generated in the logs, and banner ads don't load on the homepage
+
+Modify this functionality in `services/frontend/components/common/Ad/Ad.tsx` and respective Ads service being used.
+
+### Random frontend API errors
+
+The `api-errors` feature flag introduces random errors that occur in the frontend service's `/api` routes.
+
+**How to use**:
+
+1. Start the app via `docker compose up`
+1. Set the `api-errors` feature flag to `true`
+1. Visit `http://localhost` and reload the home page a few times, footer links will randomly return 400s and 500s.
+
+Modify this functionality in `services/frontend/pages/api/*`.
+
+### Frustration Signals in RUM
+
+The `product-card-frustration` feature flag swaps out the product card component with a version that doesn't have the thumbnails linked to the product page. When paired with the Puppeteer service, this can be used to demonstrate Frustration Signals in RUM.
+
+**How to use**:
+
+1. Start the app via `docker compose up`
+1. Set the `product-card-frustration` feature flag to `true`
+1. Visit `http://localhost/products` and try clicking on the product thumbnails to see the frustration signal in action.
+
+Modify this functionality in `services/frontend/components/Product/ProductCard.tsx` and `services/frontend/components/Product/ProductCard-v2.tsx`.

--- a/Makefile
+++ b/Makefile
@@ -1,116 +1,200 @@
-# Docker Compose files
+# =============================================================================
+# Storedog Application Makefile
+# =============================================================================
+# This Makefile provides convenient commands for managing the Storedog app
+# using Docker Compose. 
+#
+# run `make help` to see all available commands. 
+#
+# Note: All commands use the ENV variable to determine which docker-compose.yml
+# file to use. Set your preferred environment below before running commands.
+# =============================================================================
+
+# Environment settings: prod, dev, dev-frontend-prod
+ENV=dev
+
 DC=docker compose
-COMPOSE_FILE=docker-compose.yml
-COMPOSE_DEV_FILE=docker-compose.dev.yml
+COMPOSE_FILE=docker-compose.yml              # Production compose file
+COMPOSE_DEV_FILE=docker-compose.dev.yml      # Development compose file
+COMPOSE_FRONTEND_PROD_FILE=docker-compose.dev.frontend-prod.yml # Frontend production compose file
 
-# Default environment
-ENV=prod
-
-# Optional follow flag for logs
-FOLLOW?=
-
-# Colors for pretty output
+# Terminal Colors for Better UX
 GREEN=\033[0;32m
+HOT_PINK=\033[0;95m
 NC=\033[0m # No Color
 
-.PHONY: help up down restart ps logs clean build dev prod dd-dev dd-prod backup-db
+# Helper function to select the appropriate compose file based on environment
+define get_compose_file
+$(if $(filter dev,$(ENV)),$(COMPOSE_DEV_FILE),$(if $(filter dev-frontend-prod,$(ENV)),$(COMPOSE_FRONTEND_PROD_FILE),$(COMPOSE_FILE)))
+endef
 
-help: ## Show this help menu
-	@echo "Usage: make [TARGET] [ENV=prod|dev] [FOLLOW=f]"
-	@echo "For logs: make logs [service_name] [ENV=prod|dev] [FOLLOW=f]"
-	@echo ""
-	@echo "Targets:"
+.PHONY: help prepare-release up down restart stop ps logs clean build backup-db frontend-prod
+
+help: ## Show this comprehensive help menu
+	@echo "${GREEN}===============================================================================${NC}"
+	@echo "${GREEN}                        Storedog Application Commands${NC}"
+	@echo "${GREEN}===============================================================================${NC}"
+
 	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
-		helpMessage = match(lastLine, /^## (.*)/); \
-		if (helpMessage) { \
-			helpCommand = substr($$1, 0, index($$1, ":")-1); \
-			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
-			printf "  ${GREEN}%-15s${NC} %s\n", helpCommand, helpMessage; \
+		if (match(lastLine, /^## Usage: (.*)/)) { \
+			usageText = substr(lastLine, RSTART + 10, RLENGTH - 10); \
+		} \
+		if (match(secondLastLine, /^## (.*)/)) { \
+			descText = substr(secondLastLine, RSTART + 3, RLENGTH - 3); \
+		} \
+		if (usageText && descText) { \
+			printf "  ${HOT_PINK}%-32s${NC} %s\n", usageText, descText; \
+			usageText = ""; descText = ""; \
 		} \
 	} \
-	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+	{ secondLastLine = lastLine; lastLine = $$0 }' $(MAKEFILE_LIST)
+	@echo ""
+	@echo "${GREEN}===============================================================================${NC}"
 
-## Start the containers
+# =============================================================================
+# 🚀 Container Operations
+# =============================================================================
+
+## Start containers in specified environment
+## Usage: make up [clean]
 up:
-	@if [ "$(ENV)" = "dev" ]; then \
-		echo "Starting development environment..."; \
-		$(DC) -f $(COMPOSE_DEV_FILE) up -d; \
+	@COMPOSE_FILE_PATH=$(call get_compose_file); \
+	echo "${GREEN}Using compose file: ${HOT_PINK}$$COMPOSE_FILE_PATH${NC}"; \
+	if echo "$(MAKECMDGOALS)" | grep -q "clean"; then \
+		echo "Building and starting ${HOT_PINK}$(ENV)${NC} environment without cache..."; \
+		$(DC) -f $$COMPOSE_FILE_PATH build --no-cache; \
 	else \
-		echo "Starting production environment..."; \
-		$(DC) -f $(COMPOSE_FILE) up -d; \
-	fi
+		echo "Starting ${HOT_PINK}$(ENV)${NC} environment..."; \
+	fi; \
+	$(DC) -f $$COMPOSE_FILE_PATH up -d
+	@echo "${GREEN}View the frontend at http://localhost${NC}"
 
-## Stop the containers
+## Stop all containers for this project
+## Usage: make down
 down:
-	@if [ "$(ENV)" = "dev" ]; then \
-		echo "Stopping development environment..."; \
-		$(DC) -f $(COMPOSE_DEV_FILE) down; \
-	else \
-		echo "Stopping production environment..."; \
-		$(DC) -f $(COMPOSE_FILE) down; \
-	fi
+	@echo "Stopping all Storedog containers..."
+	@$(DC) down
 
-## Restart the containers
-restart: down up
+## Restart containers using current ENV setting
+## Usage: make restart
+restart:
+	@COMPOSE_FILE_PATH=$(call get_compose_file); \
+	echo "${GREEN}Restarting containers using: ${HOT_PINK}$$COMPOSE_FILE_PATH${NC}"; \
+	$(DC) -f $$COMPOSE_FILE_PATH down; \
+	$(DC) -f $$COMPOSE_FILE_PATH up -d
+	@echo "${GREEN}View the frontend at http://localhost${NC}"
 
-## Show running containers
+## Show running containers for current environment
+## Usage: make ps
 ps:
-	@if [ "$(ENV)" = "dev" ]; then \
-		$(DC) -f $(COMPOSE_DEV_FILE) ps; \
-	else \
-		$(DC) -f $(COMPOSE_FILE) ps; \
-	fi
+	@echo "${GREEN}Current ENV: ${HOT_PINK}$(ENV)${NC}"
+	@$(DC) ps
 
-## View container logs. Usage: make logs [service_name] [FOLLOW=f]
-logs:
-	@if [ "$(ENV)" = "dev" ]; then \
-		if [ -n "$(word 2,$(MAKECMDGOALS))" ]; then \
-			echo "Viewing logs for service $(word 2,$(MAKECMDGOALS)) in development environment..."; \
-			$(DC) -f $(COMPOSE_DEV_FILE) logs $(if $(FOLLOW),-f) $(word 2,$(MAKECMDGOALS)); \
-		else \
-			echo "Viewing all logs in development environment..."; \
-			$(DC) -f $(COMPOSE_DEV_FILE) logs $(if $(FOLLOW),-f); \
-		fi \
-	else \
-		if [ -n "$(word 2,$(MAKECMDGOALS))" ]; then \
-			echo "Viewing logs for service $(word 2,$(MAKECMDGOALS)) in production environment..."; \
-			$(DC) -f $(COMPOSE_FILE) logs $(if $(FOLLOW),-f) $(word 2,$(MAKECMDGOALS)); \
-		else \
-			echo "Viewing all logs in production environment..."; \
-			$(DC) -f $(COMPOSE_FILE) logs $(if $(FOLLOW),-f); \
-		fi \
-	fi
+# =============================================================================
+# 🔧 Build & Development
+# =============================================================================
 
-## Clean up containers, networks, and volumes
-clean:
-	@if [ "$(ENV)" = "dev" ]; then \
-		$(DC) -f $(COMPOSE_DEV_FILE) down -v --remove-orphans; \
-	else \
-		$(DC) -f $(COMPOSE_FILE) down -v --remove-orphans; \
-	fi
-
-## Build or rebuild containers
+## Build containers
+## Usage: make build [service] [clean]
 build:
-	@if [ "$(ENV)" = "dev" ]; then \
-		$(DC) -f $(COMPOSE_DEV_FILE) build; \
+	@COMPOSE_FILE_PATH=$(call get_compose_file); \
+	echo "${GREEN}Using compose file: ${HOT_PINK}$$COMPOSE_FILE_PATH${NC}"; \
+	SERVICE=$(filter-out build clean,$(MAKECMDGOALS)); \
+	CACHE_FLAG="$$(if [ -n "$(filter clean,$(MAKECMDGOALS))" ]; then echo --no-cache; fi)"; \
+	if [ -n "$$SERVICE" ]; then \
+		echo "Building service ${HOT_PINK}$$SERVICE${NC} in ${HOT_PINK}$(ENV)${NC} environment..."; \
+		$(DC) -f $$COMPOSE_FILE_PATH build $$CACHE_FLAG $$SERVICE; \
 	else \
-		$(DC) -f $(COMPOSE_FILE) build; \
+		echo "Building all services in ${HOT_PINK}$(ENV)${NC} environment..."; \
+		$(DC) -f $$COMPOSE_FILE_PATH build $$CACHE_FLAG; \
 	fi
 
-## Switch to development environment
-dev:
-	@make up ENV=dev FRONTEND_COMMAND="npm run dev"
+## Stop specific service or all services
+## Usage: make stop [service]
+stop:
+	@echo "${GREEN}Current ENV: ${HOT_PINK}$(ENV)${NC}"
+	@SERVICE=$(word 2,$(MAKECMDGOALS)); \
+	if [ -n "$$SERVICE" ]; then \
+		echo "Stopping service ${HOT_PINK}$$SERVICE${NC}..."; \
+		$(DC) stop $$SERVICE; \
+	else \
+		echo "Stopping all services..."; \
+		$(DC) stop; \
+	fi
 
-## Switch to production environment
-prod:
-	@make up ENV=prod FRONTEND_COMMAND="npm run prod"
+## View container logs
+## Usage: make logs [service] [follow]
+logs:
+	@echo "${GREEN}Current ENV: ${HOT_PINK}$(ENV)${NC}"
+	@SERVICE=$(filter-out logs follow,$(MAKECMDGOALS)); \
+	if echo "$(MAKECMDGOALS)" | grep -q "follow"; then \
+		FOLLOW_FLAG="-f"; \
+	else \
+		FOLLOW_FLAG=""; \
+	fi; \
+	if [ -n "$$SERVICE" ]; then \
+		echo "Viewing logs for service ${HOT_PINK}$$SERVICE${NC}..."; \
+		$(DC) logs $$FOLLOW_FLAG $$SERVICE; \
+	else \
+		echo "Viewing all logs..."; \
+		$(DC) logs $$FOLLOW_FLAG; \
+	fi
 
-## Create a database backup
+## Clean up containers, networks, and volumes (destructive)
+## Usage: make clean
+clean:
+	@COMPOSE_FILE_PATH=$(call get_compose_file); \
+	$(DC) -f $$COMPOSE_FILE_PATH down -v --remove-orphans
+
+# =============================================================================
+# ⚙️ Special Operations
+# =============================================================================
+
+## Generate production compose file for release
+## Usage: make prepare-release
+prepare-release:
+	@echo "${GREEN}Transforming ${HOT_PINK}docker-compose.dev.yml${GREEN} to ${HOT_PINK}docker-compose.generated.yml${GREEN}...${NC}"
+	@python3 scripts/transform_compose.py docker-compose.dev.yml docker-compose.generated.yml
+	@echo "${GREEN}✓ Production compose file generated successfully!${NC}"
+	@echo ""
+	@echo "📄 Generated file: ${HOT_PINK}docker-compose.generated.yml${NC}"
+	@echo "Please review the generated file in another terminal or editor before proceeding."
+	@echo ""
+	@read -p "Have you reviewed the file? Replace docker-compose.yml? [y/N]: " confirm; \
+	if [ "$$confirm" = "y" ] || [ "$$confirm" = "Y" ]; then \
+		cp docker-compose.generated.yml docker-compose.yml; \
+		echo "${GREEN}✓ ${HOT_PINK}docker-compose.yml${GREEN} has been updated!${NC}"; \
+		rm -f docker-compose.generated.yml; \
+		echo "${GREEN}✓ Cleaned up ${HOT_PINK}docker-compose.generated.yml${NC}"; \
+	else \
+		echo "Skipped replacing ${HOT_PINK}docker-compose.yml${NC}. Generated file saved as ${HOT_PINK}docker-compose.generated.yml${NC}"; \
+	fi
+
+## Create PostgreSQL database backup
+## Usage: make backup-db
 backup-db:
 	@echo "Creating database backup..."
 	@sh ./scripts/backup-db.sh
 	@echo "Backup completed. New restore.sql file created in services/postgres/db/"
 
-# Special target to allow passing service name as argument
+## Generate a dev compose with prod frontend target
+## Usage: make frontend-prod
+frontend-prod:
+	@echo "${GREEN}Transforming frontend service to production...${NC}"
+	@# Remove volumes and change target to production for frontend service only
+	@python3 scripts/transform_compose_frontend.py
+	@echo "${GREEN}✓ Frontend transformation completed!${NC}"
+	@echo "${GREEN}Generated: ${HOT_PINK}docker-compose.dev.frontend-prod.yml${NC}"
+	@echo ""
+	@echo "${GREEN}Next steps:${NC}"
+	@echo "1. Update the ENV at the top of the Makefile to ${HOT_PINK}dev-frontend-prod${NC}"
+	@echo "2. Run ${HOT_PINK}make up${NC} to start containers with this configuration"
+
+# =============================================================================
+# Special Targets
+# =============================================================================
+
+# This special target allows passing service names as arguments to other targets
+# Example: make logs frontend -> SERVICE=$(word 2,$(MAKECMDGOALS)) will be "frontend"
 %:
 	@:

--- a/README.md
+++ b/README.md
@@ -1,447 +1,107 @@
 # Storedog
 
-Storedog is a Dockerized e-commerce site used primarily in labs run at [learn.datadoghq.com](https://learn.datadoghq.com). It consists of multiple services:
+Storedog is a Dockerized e-commerce site used primarily in labs run at [learn.datadoghq.com](https://learn.datadoghq.com). 
 
-- **Frontend**: A Next.js app that serves the homepage and product pages.
-- **Backend**: A Rails app built using the Spree e-commerce framework that provides the main product catalog and order management APIs. Also includes a Redis cache.
-- **Ads**: A service that serves banner ads to the homepage. The Java version of the service is primarily used, but see [the Python service's README](./services/ads/python/README.md) for details on how to run that one in it's place
-- **Discounts**: A Python service that provides a discount API for the frontend.
-- **Postgres**: A Postgres database that stores the product catalog and order data, as well as the Discount service's data.
-- **Nginx**: A reverse proxy that routes requests to the appropriate service. Also known as `service-proxy`. 
-- **DBM**: An optional Python service that runs a long-running query to demonstrate Database Monitoring. See [the DBM service's README](./services/dbm/README.md) for details on how to run this service.
-- **The Datadog Agent**: collects metrics and traces from the other services and sends them to Datadog.
-- **Puppeteer**: A Node.js service that runs a headless browser to generate RUM data for the frontend.
+**Table of contents**
+
+- [Services](#services)
+- [Optional features](#optional-features)
+- [Local development](#local-development)
+- [Production development](#production-development)
+  - [Preparing for a Storedog release](#preparing-for-a-storedog-release)
+  - [Preparing for lab use](#preparing-for-lab-use)
+- [Image publication](#image-publication)
+- [Contributing](#contributing)
+
+## Services
+
+Storedog consists of multiple services:
+
+| Service | Technology | Description |
+|---------|------------|-------------|
+| **Ads** | Java | A service that serves banner ads to the homepage. The Java version of the service is primarily used, but see [the Python service's README](./services/ads/python/README.md) for details on how to run that one in it's place |
+| **Backend** | Rails (Spree) | A Rails app built using the Spree e-commerce framework that provides the main product catalog and order management APIs. Also includes a Redis cache. |
+| **DBM** | Python | An optional Python service that runs a long-running query to demonstrate Database Monitoring. See [the DBM service's README](./services/dbm/README.md) for details on how to run this service. |
+| **Discounts** | Python | A Python service that provides a discount API for the frontend. |
+| **Frontend** | Next.js | A Next.js app that serves the homepage and product pages. |
+| **Nginx** | Nginx | A reverse proxy that routes requests to the appropriate service. Also known as `service-proxy`. |
+| **Postgres** | PostgreSQL | A Postgres database that stores the product catalog and order data, as well as the Discount service's data. |
+| **Puppeteer** | Node.js | A Node.js service that runs a headless browser to generate RUM data for the frontend. |
+| **The Datadog Agent** | Datadog | Collects metrics and traces from the other services and sends them to Datadog. |
+
+Each service has a `README.md` file with more information.
 
 > [!NOTE]
-> This application is built and tested to run within [Datadog Learning Center](https://learn.datadoghq.com/) lab environments. This application can be run outside of the Datadog Learning Center lab environments, but some features may not work as expected. 
-> 
+> This application is built and tested to run within [Datadog Learning Center](https://learn.datadoghq.com/) lab environments. This application can be run outside of the Datadog Learning Center lab environments, but some features may not work as expected.
+>
 > This documentation includes instructions for running the application locally and in lab environments.
 
 Many parts of this application were intentionally modified to introduce performance issues, security vulnerabilities, and other intentionally problematic code. This is to help you learn how to use Datadog to troubleshoot and fix these issues. This application is not intended to be used in production.
 
-## Local development
-
-The Storedog application comes pre-configured with default environment variable values for all services. You just need to run `docker compose -f docker-compose.dev.yml up -d` and you're good to go. These defaults are baked into the following files for your convenience and reference:
-
-- Service Dockerfiles
-- docker-compose.dev.yml
-- .env.template
-
-> [!NOTE]
-> The production `docker-compose.yml` file is primarily used for lab environments. If you want to run the application in production, you can use the `docker-compose.yml` file, but you'll need to set image versions or build local images of the services.
->
-> You'll also notice the `docker-compose.yml` file has less environment variables set. This is to make it easier to run in lab environments and rely more on default values.
-
-The only values you need to provide are your Datadog credentials to enable Datadog features. You can set these in the Docker Compose file, on the host, or in a `.env` file. If you use the `.env` file, you can use the `.env.template` file as a reference for the available variables.
-
-See the [Environment Variables](#environment-variables) section below for more details on the available environment variables.
-
-> [!WARNING]
-> While you can mix and match the environment variables in the Docker Compose file, host, and `.env` file, be mindful of the order of precedence. See the [Docker Compose documentation](https://docs.docker.com/compose/compose-file/compose-file-v3/#environment-variables) for more details.
-
-### Using the Docker Compose file
-
-1. Go into the Docker Compose file and set or overwrite the environment variables you need to override.
-
-  ```yaml
-  environment:
-    - DD_API_KEY=your_datadog_api_key
-    - DD_APP_KEY=your_datadog_app_key
-  ```
-
-### Using the host
-
-1. Set the environment variables in your shell
-
-  ```sh
-  export DD_API_KEY=your_datadog_api_key
-  export DD_APP_KEY=your_datadog_app_key
-  ```
-
-### Using the `.env` file
-
-1. Copy the environment template:
-
-  ```sh
-  cp .env.template .env
-  ```
-
-1. Open the `.env` file and provide your Datadog credentials:
-   - `DD_API_KEY`: Required for Datadog Agent and APM
-   - `DD_APP_KEY`: Required for Datadog API access
-   - `NEXT_PUBLIC_DD_APPLICATION_ID`: Required for RUM in frontend service
-   - `NEXT_PUBLIC_DD_CLIENT_TOKEN`: Required for RUM in frontend service
-
-   You can find or create these values in your Datadog organization. All other variables have sensible defaults and can be left as-is.
-
-### Starting the application
-
-1. Start the application:
-
-  ```sh
-  docker compose -f docker-compose.dev.yml up -d
-  ```
-
-  > [!NOTE]
-  > You can also use the commands in the [Makefile](./Makefile) to start the application. For example, `make dev` will start the application in development mode.
-  >
-  > Run `make help` to see all of the available commands.
-
-1. Visit http://localhost to use the app. The homepage will take a few seconds to load as the backend services initialize.
-
-   If you see a 502 error for an extended period, check the service health with:
-
-   ```sh
-   docker compose -f docker-compose.dev.yml logs <service-name>
-   ```
-
-> [!NOTE]
-> By default, the frontend service runs in development mode when using `docker compose -f docker-compose.dev.yml up -d`. If you want to run it in production, you can set the `FRONTEND_COMMAND` environment variable to `npm run prod`. This can be done either in the compose file, on the host, or in the `.env` file.
-
-## Environment Variables
-
-### Core Datadog Variables
-
-These variables must be set for core functionality with Datadog, but will not affect the application's behavior. Find these values in your Datadog organization's settings, you'll need to create a RUM application for the `DD_APPLICATION_ID` and `DD_CLIENT_TOKEN` values.
-
-- `DD_API_KEY`: Your Datadog API key (required for monitoring)
-- `DD_APP_KEY`: Your Datadog application key (required for API access)
-- `NEXT_PUBLIC_DD_APPLICATION_ID`: Datadog RUM application ID (required for RUM in frontend service)
-- `NEXT_PUBLIC_DD_CLIENT_TOKEN`: Datadog RUM client token (required for RUM in frontend service)
-
-### Frontend Service Variables
-
-- `FRONTEND_COMMAND`: Command to run the frontend service (default: `npm run dev`)
-
-> [!IMPORTANT]
-> This variable is set on the host or in the `.env` file. It is not set in the Docker Compose file, as `command` attribute values in compose files cannot reference variable definitions directly set in the `environment` attribute.
-
-- `NEXT_PUBLIC_ADS_ROUTE`: Route to the ads service (default: `/services/ads`)
-- `NEXT_PUBLIC_DISCOUNTS_ROUTE`: Route to the discounts service (default: `/services/discounts`)
-- `NEXT_PUBLIC_DBM_ROUTE`: Route to the DBM service (default: `/services/dbm`)
-- `NEXT_PUBLIC_FRONTEND_API_ROUTE`: Frontend API host (default: `http://service-proxy:80`)
-- `NEXT_PUBLIC_SPREE_API_HOST`: Spree API host (default: `http://service-proxy/services/backend`)
-- `NEXT_PUBLIC_SPREE_CLIENT_HOST`: Spree client host (default: `/services/backend`)
-- `NEXT_PUBLIC_SPREE_IMAGE_HOST`: Spree image host (default: `/services/backend`)
-- `NEXT_PUBLIC_SPREE_ALLOWED_IMAGE_DOMAIN`: Allowed image domain (default: `service-proxy`)
-
-> [!NOTE]
-> You'll notice some need the `http://service-proxy` prefix is used in some of the variables. The reason for this difference those specific calls are made from Next.js API routes, which require a full URL to the service. 
->
-> The ones without the `http://service-proxy` prefix are used in the frontend service's `fetch` calls, which are made from the browser and are caught by the nginx service, because it intercepts calls to Next.js API routes and routes them to the appropriate service.
-
-### Database Variables
-
-- `POSTGRES_USER`: Database username (default: `postgres`)
-- `POSTGRES_PASSWORD`: Database password (default: `postgres`)
-- `DB_HOST`: PostgreSQL host (default: `postgres`)
-- `DB_PORT`: PostgreSQL port (default: `5432`)
-- `DB_POOL`: Database connection pool size (default: `25`)
-
-### Backend and Worker Variables
-
-- `REDIS_URL`: Redis connection URL (default: `redis://redis:6379/0`)
-- `MAX_THREADS`: Maximum worker threads (default: `5`)
-- `RAILS_ENV`: Rails environment (default: `production`)
-
-### Datadog Configuration Variables
-
-Common Datadog variables that can be set in application services:
-
-- `DD_ENV`: Environment name
-- `DD_SITE`: Datadog site (e.g., `datadoghq.com`, `datadoghq.eu`)
-- `DD_HOSTNAME`: Override default hostname
-- `DD_LOGS_INJECTION`: Enable log injection into traces. Some languages' trace libraries turn this on by default, but we turn it on explicitly to prevent confusion.
-- `DD_PROFILING_ENABLED`: Enable the Continuous Profiler 
-- `DD_RUNTIME_METRICS_ENABLED`: Enable runtime metrics
-
-Service-specific versions:
-- `DD_VERSION_FRONTEND`: Frontend version (default: `1.0.0`)
-- `DD_VERSION_BACKEND`: Backend version (default: `1.0.0`)
-- `DD_VERSION_DISCOUNTS`: Discounts service version (default: `1.0.0`)
-- `DD_VERSION_ADS`: Ads service version (default: `1.0.0`)
-- `DD_VERSION_ADS_PYTHON`: Ads Python service version (default: `1.0.0`)
-- `DD_VERSION_NGINX`: nginx service version (default: `1.28.0`)
-- `DD_VERSION_POSTGRES`: PostgreSQL service version (default: `15.0`)
-- `DD_VERSION_REDIS`: Redis version (default: `6.2`)
-
-> [!NOTE]
-> Most of the time, these service versions will remain at the same version as one another. The reason for having them defined separately is to allow for the ability to change the version of one service without having to change the version of all of the other services, something that may be common when working in a lab environment.
-
-### Puppeteer user session simulation variables
-
-Puppeteer service configuration:
-- `STOREDOG_URL`: Application URL to run user sessions on (default: `http://service-proxy:80`) 
-  - In lab environments, use the URL running on the host instead to have more realistic looking URLs in your session data.
-
-  ```
-  STOREDOG_URL=$HOSTNAME.$_SANDBOX_ID.instruqt.io
-  ```
-
-  > [!NOTE]
-  > The `$HOSTNAME` and `$_SANDBOX_ID` variables are automatically set by Instruqt. Notice how this differs from what is used in the Storedog website tab in lab environments (`https://[HOSTNAME]-[PORT]-[PARTICIPANT_ID].env.play.instruqt.com`), as that is for authenticated traffic and the Puppeteer service is using an unauthenticated session.
-  >
-  > There is no need for a port in the URL, as the nginx service is configured to listen on port 80.
-
-- `PUPPETEER_TIMEOUT`: Sets max timeout for Puppeteer, in case the session is unresponsive
-- `SKIP_SESSION_CLOSE`: Skip closing browser sessions
-
-### Nginx/Service Proxy Configuration Variables
-
-These variables control the upstream configuration for the ads services in the Nginx (service-proxy) container, enabling A/B testing and traffic splitting between the Java and Python ads services.
-
-> [!IMPORTANT]
-> When `ADS_B_PERCENT` is greater than zero, the `ADS_B_UPSTREAM` endpoint must be reachable. Otherwise, the service-proxy will crash and restart. Uncomment the `ads-python` section in `docker-compose.yml` to enable the service.
-
-- `ADS_A_UPSTREAM`: Host and port for the primary (A) ads service (default: `ads:3030`)
-- `ADS_B_UPSTREAM`: Host and port for the secondary (B) ads service (default: `ads-python:3030`)
-- `ADS_B_PERCENT`: Percentage of traffic to route to the B (Python) ads service (default: `0`). The remainder goes to the A (Java) ads service.
-  - Set to a value between `0` and `100` to control the split.
-
 ## Optional features
 
-There are several features that can be enabled by setting environment variables and feature flags.
+Several different features can be enabled using either feature flags or by modifying the `docker-compose.yml` file.
 
-### A/B Testing Ads services
+Read [FEATURES.md](FEATURES.md) for more information.
 
-Run two Ads services and split traffic between them. The amount of traffic sent to each service is set with a percent value.
+## Local development
 
-This requires running a second Ads service in addition to the default Java Ads service and setting environment variables in the `service-proxy` service. The Python Ads service is typically used as the secondary service.
+1. Set environment variables.
 
-1. Set an environment variable for the Python Ads service version.
+    The Storedog application comes pre-configured with default environment variable values for all services. The services will run, but Datadog functionality will not work.
 
-    ```bash
-    export DD_VERSION_ADS_PYTHON=1.0.0
-    ```
-
-1. These environment variables need to be set for the `service-proxy` service.
-
-    - `ADS_A_UPSTREAM`: Host and port for the primary (A) ads service (default: `ads:3030`)
-    - `ADS_B_UPSTREAM`: Host and port for the secondary (B) ads service (default: `ads-python:3030`)
-    - `ADS_B_PERCENT`: Percentage of traffic to route to the B (Python) ads service (default: `0`). The remainder goes to the A ads (Java) service.
-      - Set a value between `0` and `100` to control the split.
-
-**How to use**
-
-#### Docker Compose
-1. Add a second Ads service to the `docker-compose.yml`
-
-    ```yaml
-      # OPTIONAL: Advertisement service (Python)
-      ads-python:
-        image: ghcr.io/datadog/storedog/ads-python:${STOREDOG_IMAGE_VERSION:-latest}
-        build: # Only used if building from source in development
-          context: ./services/ads/python
-        depends_on:
-          - postgres
-          - dd-agent
-        environment:
-          - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-          - POSTGRES_USER=${POSTGRES_USER:-postgres}
-          - POSTGRES_HOST=postgres
-          - DD_AGENT_HOST=dd-agent
-          - DD_ENV=${DD_ENV:-production}
-          - DD_SERVICE=store-ads-python
-          - DD_VERSION=${DD_VERSION_ADS_PYTHON:-1.0.0}
-          - DD_PROFILING_ENABLED=true
-          - DD_PROFILING_TIMELINE_ENABLED=true
-          - DD_PROFILING_ALLOCATION_ENABLED=true
-        volumes: # Only used in development
-          - ./services/ads/python:/app
-        networks:
-          - storedog-network
-        labels:
-          com.datadoghq.ad.logs: '[{"source": "python"}]'
-    ```
-
-1. Add these environment variables to the `service-proxy` service in the `docker-compose.yml` file:
-
-    ```yaml
-    environment:
-      - ADS_A_UPSTREAM=${ADS_A_UPSTREAM:-ads:3030}
-      - ADS_B_UPSTREAM=${ADS_B_UPSTREAM:-ads-python:3030}
-      - ADS_B_PERCENT=${ADS_B_PERCENT:-0}
-    ```
-
-1. Start the app via `docker compose up -d`
-
-#### Kubernetes
-
-A Kubernetes manifest for the Python Ads service is available in the `services/ads/k8s-manifests/` directory.
-
-1. Add the `ads-python.yaml` file to the `k8s-manifests/storedog-app/deployments/` directory.
-
-1. Add the following environment variables to the `nginx.yaml` file and adjust as needed:
-
-    ```yaml
-    # A/B testing ads services
-    - name: ADS_A_UPSTREAM
-      value: "ads:3030"
-    - name: ADS_B_UPSTREAM
-      value: "ads-python:3030"
-    - name: ADS_B_PERCENT
-      value: "50"
-    ```
-
-1. Follow the instructions in the [Kubernetes README](./k8s-manifests/README.md) to run Storedog in Kubernetes.
-
-1. If the Storedog is already running, apply the manifests to the cluster:
+    If you want to test Datadog functionality (the Agent, APM, RUM) set the variables listed in the the `env.development.template` file. You can copy the file with the command below. Use the keys/tokens/ID from a trial account or a dogfood account.
 
     ```bash
-    envsubst < k8s-manifests/storedog-app/deployments/ads-python.yaml | kubectl apply -n storedog -f -
-    envsubst < k8s-manifests/storedog-app/deployments/nginx.yaml | kubectl apply -n storedog -f -
+    cp env.development.template .env
     ```
 
-> [!IMPORTANT]
-> Be sure to set the `DD_VERSION_ADS_PYTHON` environment variable so that it will be applied to the file by `envsubst`.
+    To learn more about each environment variable, check out the `env.template`, the `docker-compose` files, and each service's `Dockerfile`s.
 
-### Feature flags
+    > [!TIP]
+    >
+    > Use the `.env` file.
+    >
+    > There are several ways to pass environment variables to Docker Compose, which could lead to unintentional value overwrites. See the [Docker Compose documentation](https://docs.docker.com/compose/compose-file/compose-file-v3/#environment-variables) for more details.
 
-Some capabilities are hidden behind feature flags, which can be controlled via `services/frontend/site/featureFlags.config.json`. 
+1. Build and run the development containers.
 
-> [!NOTE]
-> Feature flags are available by default when running the application in development mode. If running in production, you'll need update the file and mount it into the frontend service container in the `docker-compose.yml` file.
->
-> ```yaml
-> volumes:
->   - ./services/frontend/site/featureFlags.config.json:/app/featureFlags.config.json
-> ```
+    To build and run Storedog's services using development builds, run the following command from the root directory (`storedog/`):
 
-#### dbm 
+    ```bash
+    make dev
+    ```
 
-Enables a product ticker on the homepage with a long-running query to demonstrate DBM. 
+    Open Storedog's frontend in your browser at [http://localhost](http://localhost/).
 
-**How to use**:
-1. First, set up the DBM service as described in the [DBM README](./services/dbm/README.md)
-1. Start the app via `docker compose up`
-1. Set the `dbm` feature flag to true
-1. Visit http://localhost and reload the home page a few times
-1. The ticker will appear after 5 seconds and will subsequently update every 5 seconds with a new product and amount ordered
+    > [!TIP]
+    >
+    > Read the `Makefile` to see other useful commands.
 
-You can modify the ticker functionality in `services/frontend/components/common/NavBar.tsx`.
+## Production development
 
-#### error-tracking 
+### Preparing for a Storedog release
 
-Introduces an exception in the Ads services to demonstrate Error Tracking by setting a header in to a value that is not expected by the Ads service.
+After developing locally, you can generate a prod `docker-compose.yml` file with `make prepare-release`. 
 
-**How to use**:
-1. Start the app via `docker compose up`
-1. Set the `error-tracking` feature flag to true
-1. Visit http://localhost and reload the home page a few times
-1. You should start seeing 500s being generated in the logs, in addition to the banner ads not loading on the homepage
+This is primarily for building Storedog release images. (This is experimental, so please carefully read the `docker-compose.generated.yml` file before replacing the `docker-compose.yml` file.)
 
-Modify this functionality in `services/frontend/components/common/Ad/Ad.tsx` and respective Ads service being used.
+You won't be able to test the production `docker-compose.yml` file as written. This file relies on pre-built images rather than a local build context, so any local changes to service files won't be used by Docker Compose. This is expected.
 
-#### api-errors
+### Preparing for lab use
 
-This introduces random errors that occur in the frontend service's `/api` routes.
+In a lab environment, you may need to rely on local build contexts or mount volumes with customized files. Therefore, your lab's `docker-compose.yml` file may look like a mix of both the `docker-compose.yml` and `docker-compose.dev.yml` files.
 
-**How to use**:
-1. Start the app via `docker compose up`
-1. Set the `api-errors` feature flag to true
-1. Visit http://localhost and reload the home page a few times, footer links will randomly return 400s and 500s.
+You can likely remove several environment variables from your `docker-compose.yml`, since default values are set. Check each service's `Dockerfile` to see which variables have default values.
 
-Modify this functionality in `services/frontend/pages/api/*`.
-
-#### product-card-frustration
-
-This will swap out the product card component with a version that doesn't have the thumbnails linked to the product page. When paired with the Puppeteer service, this can be used to demonstrate Frustration Signals in RUM.
-
-**How to use**:
-1. Start the app via `docker compose up`
-1. Set the `product-card-frustration` feature flag to true
-1. Visit http://localhost/products and try clicking on the product thumbnails to see the frustration signal in action.
-
-Modify this functionality in `services/frontend/components/Product/ProductCard.tsx` and `services/frontend/components/Product/ProductCard-v2.tsx`.
+Check out the [template course](https://github.com/DataDog/learning-center/tree/main/templates/labs/storedog-template) to see how to set up a lab that uses Storedog.
 
 ## Image publication
 
-Images are stored in GHCR. On PR merges, only the affected services will be pushed to GHCR, using the `latest` tag. For example, if you only made changes to the `backend` service, then only the `backend` Github workflow will trigger and publish `ghcr.io/datadog/storedog/backend:latest`. 
+Images are stored in GHCR. On PR merges, only the affected services will be pushed to GHCR, using the `latest` tag. For example, if you only made changes to the `backend` service, then only the `backend` Github workflow will trigger and publish `ghcr.io/datadog/storedog/backend:latest`.
 
 Separately, we tag and publish *all* images when a new release is created with the corresponding release tag e.g. `ghcr.io/datadog/storedog/backend:1.0.1`. New releases are made on an ad-hoc basis, depending on the recent features that are added.
 
-## Breakdown of services
-
-All of the services in the Storedog application are Dockerized and run in containers. See the [docker-compose.yml](./docker-compose.yml) file for the full list of services and how they are connected. You'll also find specific Datadog configurations, volume mounts, and environment variables for each service in there.
-
-Below is a breakdown of services and some instructions on how to use them.
-
-### Ads
-
-There are two advertisement services, the default service is built in Java and there is another option available in Python. These services do the same thing, have the same endpoints, run on the same port (`3030`), and have the same failure modes. These ads are served through the `Ads.tsx` component in the frontend service.
-
-To switch between the Java and Python services, see the instructions in the [Ads service README](./services/ads/README.md).
-
-### Backend
-
-The backend service is where all of the product and order data is managed. It is built using the Spree e-commerce framework, which is a Ruby on Rails application.
-
-It's accessible at `http://localhost:4000`, but there's nothing at that path since we run the service as a headless API. The admin interface is available at `http://localhost:4000/admin`. Login with the following credentials to access the admin interface if you would like to add products or manage orders:
-
-```
-Username: admin@storedog.com
-Password: password
-```
-
-If you make any changes to the backend service, you will need to rebuild the Docker image to ensure new images uploaded are saved. You'll also need to create a restore point to ensure the new images are available in the database. 
-
-#### Database rebuild
-
-To create a new `.sql` restore file, run the following command while the application is running.
-
-```sh
-sh ./scripts/backup-db.sh
-```
-
-This will create a new `restore.sql` file in the `services/postgres/db/` directory and get it set up with all of necessary SQL statements to prepare the database for Datadog monitoring. When done running, you'll want to rebuild the Postgres database image with the new restore point. 
-
-#### Worker
-
-The Spree application has a worker process that runs in the background. There is a specific Datadog tracer configuration for it in the `services/worker/` directory and is mounted into the worker container.
-
-### Discounts
-
-The discounts service is a Python service that provides an API for serving discount codes to the frontend that can be used to apply discounts to orders. The discounts are stored in a Postgres database and are served through the `Discounts.tsx` component in the frontend service.
-
-Currently, when applying a successful discount code, we it will automatically apply a "Free shipping" discount that exists in the backend service. This is to demonstrate the discount functionality in the frontend, but is a bit of a hack.
-
-### Frontend
-
-The frontend service is a Next.js application that serves the homepage and product pages. It is accessible at `http://localhost`.
-
-In the shipped `docker-compose.yml` file, the frontend service is set to run in development mode, which means it will automatically reload when you make changes to the code. If you want to run the frontend service in production mode, you can do so by changing the `command` in the `frontend` service in the `docker-compose.yml` file to `npm run build && npm run start`.
-
-### Postgres
-
-The Postgres service is a Postgres database that stores the product catalog and order data, as well as the discount data for the discounts service.
-
-There's information under the [Backend](#backend) section on how to rebuild the Postgres database image with a new restore point.
-
-The Postgres service also has logging set up to write to a JSON file and a fairly quick log rotation, which get saved in a Docker volume. 
-
-### nginx
-
-The nginx service is a reverse proxy that handles requests for both the frontend and backend API services. It is accessible at `http://localhost`.
-
-When viewing information about the application in Datadog, you'll see it referenced as `service-proxy`.
-
-### DBM
-
-The DBM service is an optional Python service that runs a long-running query to demonstrate Database Monitoring. See [the DBM service's README](./services/dbm/README.md) for details on how to run this service.
-
-### Puppeteer
-
-The Puppeteer service is a Node.js service that runs a headless browser to generate RUM data for the frontend.
-
-It's a pre-built image that has sessions defined to run on the application, found in `services/puppeteer/scripts/puppeteer.js` but you can use Docker volume mounts to bring in your own customized sessions.
-
-```sh
-# add this to puppeteer service definition in a Docker Compose file
-volumes:
-  - ./services/puppeteer/scripts/puppeteer.js:/home/pptruser/puppeteer.js
-```
-
 ## Contributing
 
-While we don't accept contributions to the Storedog project from members outside of Datadog, we encourage you to fork the project and make it your own! 
-
+While we don't accept contributions to the Storedog project from members outside of Datadog, we encourage you to fork the project and make it your own!

--- a/services/ads/CHANGELOG.md
+++ b/services/ads/CHANGELOG.md
@@ -13,3 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 ### Changed
 
 - Replaced the `wait-for-it` package with `netcat-openbsd` in the Python ads Dockerfile; startup ordering is now handled by Compose healthchecks.
+
+### Documentation
+
+- Expanded the service `README.md` (Java/Python variants overview, `DD_VERSION_ADS_PYTHON` versioning).

--- a/services/ads/README.md
+++ b/services/ads/README.md
@@ -1,5 +1,7 @@
 # Advertisements Service
 
+There are two advertisement services, the default service is built in Java and there is another option available in Python. These services do the same thing, have the same endpoints, run on the same port (`3030`), and have the same failure modes. These ads are served through the `Ads.tsx` component in the frontend service.
+
 ## Description
 
 This service is responsible for managing the banner advertisements served to the frontend service of the application. There are two variations of this service, one uses Python and the other uses Java.
@@ -248,7 +250,7 @@ spec:
             - name: DD_SERVICE
               value: store-ads
             - name: DD_VERSION
-              value: ${DD_VERSION_ADS}
+              value: ${DD_VERSION_ADS_PYTHON}
             - name: DD_RUNTIME_METRICS_ENABLED
               value: "true"
             - name: DD_PROFILING_ENABLED

--- a/services/backend/CHANGELOG.md
+++ b/services/backend/CHANGELOG.md
@@ -18,3 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 ### Removed
 
 - The `wait-for-it` package and `wait-for-it` startup wrapper from the Dockerfile; startup ordering is now handled by Compose healthchecks.
+
+### Documentation and dependencies
+
+- Expanded the service `README.md` (admin URL/credentials, worker process notes).
+- Bumped gems in `Gemfile.lock` (`datadog-ruby_core_source` to 3.5.2, `libddwaf` to 1.24.1.2.1) and pruned redundant platform-specific entries.

--- a/services/backend/Gemfile.lock
+++ b/services/backend/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/sass/sassc-ruby.git
-  revision: 4fce2b635ca5d616a8b1381c64846410bc785ea4
-  specs:
-    sassc (2.4.0)
-      ffi (~> 1.9)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -133,7 +126,6 @@ GEM
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
     bcrypt (3.1.16)
-    bigdecimal (3.2.2)
     bindex (0.8.1)
     bootsnap (1.10.2)
       msgpack (~> 1.2)
@@ -174,10 +166,10 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    datadog (2.18.0)
+    datadog (2.21.0)
       datadog-ruby_core_source (~> 3.4, >= 3.4.1)
       libdatadog (~> 18.1.0.1.0)
-      libddwaf (~> 1.24.1.0.0)
+      libddwaf (~> 1.24.1.2.1)
       logger
       msgpack
     datadog-ruby_core_source (3.4.1)
@@ -192,7 +184,7 @@ GEM
       devise (>= 2.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    dogstatsd-ruby (5.6.6)
+    dogstatsd-ruby (5.7.1)
     doorkeeper (5.5.4)
       railties (>= 5)
     dotenv (2.7.6)
@@ -485,8 +477,15 @@ GEM
     ruby2_keywords (0.0.5)
     ruby_http_client (3.5.3)
     rubyzip (2.3.2)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -698,11 +697,10 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap
   dalli
-  datadog (~> 2.18.0)
-  dogstatsd-ruby (~> 5.6)
+  datadog (~> 2.21.0)
+  dogstatsd-ruby (~> 5.7.1)
   dotenv-rails (~> 2.1, >= 2.1.1)
   font_assets
-  google-protobuf (~> 4.30)
   letter_opener
   listen
   lograge
@@ -718,8 +716,9 @@ DEPENDENCIES
   rails (~> 6.1.4)
   remote_syslog_logger
   rspec_junit_formatter
+  sass (~> 3.7.4)
   sass-rails
-  sassc!
+  sassc-rails (~> 2.1.2)
   sendgrid-actionmailer
   sidekiq
   spree (>= 4.4.0)

--- a/services/backend/README.md
+++ b/services/backend/README.md
@@ -1,6 +1,16 @@
-# Backend service (product management)
-
-## Overview
+# Backend service (product management) README
 
 This service manages the products in the store. It is a Ruby on Rails application built using the Spree framework. The service is packaged as a Docker image and typically used in a Docker Compose file (see the root of this repo).
 
+It's accessible at `http://localhost:4000`, but there's nothing at that path since we run the service as a headless API. The admin interface is available at `http://localhost:4000/admin`. Login with the following credentials to access the admin interface if you would like to add products or manage orders:
+
+```
+Username: admin@storedog.com
+Password: password
+```
+
+If you make any changes to the backend service, you will need to rebuild the Docker image to ensure new images uploaded are saved. You'll also need to create a restore point to ensure the new images are available in the database.
+
+## Worker
+
+The Spree application has a worker process that runs in the background. There is a specific Datadog tracer configuration for it in the `services/worker/` directory and is mounted into the worker container.

--- a/services/discounts/CHANGELOG.md
+++ b/services/discounts/CHANGELOG.md
@@ -13,3 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 ### Changed
 
 - Replaced the `wait-for-it` package with `netcat-openbsd` in the Dockerfile; startup ordering is now handled by Compose healthchecks.
+
+### Documentation
+
+- Expanded the service `README.md` (service overview, free-shipping discount behavior, log formatting file reference fix).

--- a/services/discounts/README.md
+++ b/services/discounts/README.md
@@ -1,8 +1,12 @@
-# Discounts service
+# Discounts service README
 
 ## Description
 
 This service is responsible for managing discounts written in Python using the Flask framework. It uses a PostgreSQL database to store the discounts.
+
+The discounts service is a Python service that provides an API for serving discount codes to the frontend that can be used to apply discounts to orders. The discounts are stored in a Postgres database and are served through the `Discounts.tsx` component in the frontend service.
+
+Currently, when applying a successful discount code, we it will automatically apply a "Free shipping" discount that exists in the backend service. This is to demonstrate the discount functionality in the frontend, but is a bit of a hack.
 
 ## Datadog configuration
 
@@ -14,7 +18,7 @@ Logging is configured in the `docker-compose.yml` file along with the Datadog Ag
 
 The `ddtrace` library is used to instrument the Python service. The `ddtrace` library is installed in the `requirements.txt` file. The `ddtrace-run` command is used to run the service in the `Dockerfile`.
 
-Log injection is enabled in the `docker-compose.yml` file, but the logs are formatted in the `ads.py` file.
+Log injection is enabled in the `docker-compose.yml` file, but the logs are formatted in the `discounts.py` file.
 
 ## Endpoints
 

--- a/services/nginx/README.md
+++ b/services/nginx/README.md
@@ -1,0 +1,5 @@
+# service-proxy (nginx) service README
+
+The nginx service is a reverse proxy that handles requests for both the frontend and backend API services. It is accessible at `http://localhost`.
+
+When viewing information about the application in Datadog, you'll see it referenced as `service-proxy`.

--- a/services/postgres/README.md
+++ b/services/postgres/README.md
@@ -1,0 +1,15 @@
+# Postgres service README
+
+The Postgres service is a Postgres database that stores the product catalog and order data, as well as the discount data for the discounts service.
+
+The Postgres service also has logging set up to write to a JSON file and a fairly quick log rotation, which get saved in a Docker volume. 
+
+## Database rebuild
+
+To create a new `.sql` restore file, run the following command while the application is running.
+
+```sh
+sh ./scripts/backup-db.sh
+```
+
+This will create a new `restore.sql` file in the `services/postgres/db/` directory and get it set up with all of necessary SQL statements to prepare the database for Datadog monitoring. When done running, you'll want to rebuild the Postgres database image with the new restore point.


### PR DESCRIPTION
## Summary
- Refactors the `Makefile` (ENV-based compose selection, `prepare-release` and no-cache targets, better help) and wires it to the compose transformation scripts.
- Restructures docs: trims the root `README.md`, moves features into `FEATURES.md`, and adds/updates per-service READMEs (`ads`, `backend`, `discounts`, new `nginx`, new `postgres`).
- Reworks env templates (adds `.env.development.template`), tidies `.gitignore`, and bumps backend gems in `Gemfile.lock`.

## Stack
Part of the TRAIN-3546 split. **Base: `TRAIN-3546-compose-transform-tooling`** (Makefile consumes the transform scripts). Merge last, after #185.

## Test plan
- [ ] `make help` and confirm targets resolve.
- [ ] `make prepare-release` (or equivalent) generates the production compose file.

Made with [Cursor](https://cursor.com)