### PR TITLE
added wait-for-it command to ads-python code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ This requires running a second Ads service in addition to the default Java Ads s
         image: ghcr.io/datadog/storedog/ads-python:${STOREDOG_IMAGE_VERSION:-latest}
         build: # Only used if building from source in development
           context: ./services/ads/python
+        command: wait-for-it postgres:5432 -- ddtrace-run flask run --port=3030 --host=0.0.0.0
         depends_on:
           - postgres
           - dd-agent

--- a/services/ads/README.md
+++ b/services/ads/README.md
@@ -218,6 +218,10 @@ spec:
         - name: apmsocketpath
           hostPath:
             path: /var/run/datadog/
+      initContainers:
+        - name: wait-for-db
+          image: busybox:1.37.0
+          command: ['sh', '-c', 'until nc -z postgres 5432; do echo waiting for postgres; sleep 2; done;']
       containers:
         - name: ads
           image: ${REGISTRY_URL}/ads-python:${SD_TAG}

--- a/services/ads/README.md
+++ b/services/ads/README.md
@@ -154,6 +154,7 @@ To use the Python ads service, replace the `ads` definition with the following i
     image: ghcr.io/datadog/storedog/ads-python:${STOREDOG_IMAGE_VERSION:-latest}
     build: # Only used if building from source in development
       context: ./services/ads/python
+    command: wait-for-it postgres:5432 -- ddtrace-run flask run --port=3030 --host=0.0.0.0
     depends_on:
       - postgres
       - dd-agent

--- a/services/ads/k8s-manifests/ads-python.yaml
+++ b/services/ads/k8s-manifests/ads-python.yaml
@@ -34,6 +34,10 @@ spec:
         - name: apmsocketpath
           hostPath:
             path: /var/run/datadog/
+      initContainers:
+        - name: wait-for-db
+          image: busybox:1.37.0
+          command: ['sh', '-c', 'until nc -z postgres 5432; do echo waiting for postgres; sleep 2; done;']
       containers:
         - name: ads-python
           image: ${REGISTRY_URL}/ads-python:${SD_TAG}


### PR DESCRIPTION
## Description
When the Ads service changed to use Java by default, the code snippet for Python lost the `command` using `wait-for-it` to ensure that the database is accepting connections. This PR adds the line to the two REAME files.

## How to test
Change the docker-compose file to use the Python version of ads from the README
Run `docker compose up -d`
Run `docker compose ps` to confirm that the ads service is running
Check Storedog and confirm ads appear
