### PR TITLE
Fix frontend RUM version env var name in docker-compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,6 +51,7 @@ services:
       - NEXT_PUBLIC_DD_SITE=${NEXT_PUBLIC_DD_SITE:-datadoghq.com}
       - NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend # used for client-side Next.js RUM configuration
       - NEXT_PUBLIC_DD_ENV=${DD_ENV:-development}
+      - NEXT_PUBLIC_DD_VERSION_FRONTEND=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
       - NEXT_PUBLIC_ADS_ROUTE=${NEXT_PUBLIC_ADS_ROUTE:-/services/ads}
       - NEXT_PUBLIC_DISCOUNTS_ROUTE=${NEXT_PUBLIC_DISCOUNTS_ROUTE:-/services/discounts}
       - NEXT_PUBLIC_DBM_ROUTE=${NEXT_PUBLIC_DBM_ROUTE:-/services/dbm}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - NEXT_PUBLIC_DD_SITE=${NEXT_PUBLIC_DD_SITE:-datadoghq.com}
       - NEXT_PUBLIC_DD_SERVICE_FRONTEND=store-frontend # used for client-side Next.js RUM configuration
       - NEXT_PUBLIC_DD_ENV=${DD_ENV:-production}
-      - NEXT_PUBLIC_DD_VERSION=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
+      - NEXT_PUBLIC_DD_VERSION_FRONTEND=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}
     labels:
       com.datadoghq.ad.logs: '[{"source": "nodejs", "auto_multi_line_detection": true }]'
   backend:


### PR DESCRIPTION
## Summary

`services/frontend/pages/_app.tsx` reads `NEXT_PUBLIC_DD_VERSION_FRONTEND` directly for the RUM SDK's `version` field:

```ts
version: `${process.env.NEXT_PUBLIC_DD_VERSION_FRONTEND || '1.0.0'}`,
```

`docker-compose.yml` forwarded a container env var named `NEXT_PUBLIC_DD_VERSION` (missing the `_FRONTEND` suffix) into the frontend service, so this value never actually reached the frontend process. As a result, RUM sessions always reported version `1.0.0`, regardless of what `NEXT_PUBLIC_DD_VERSION_FRONTEND` was set to in the environment.

`docker-compose.dev.yml` didn't set this env var under either name, so dev-mode RUM sessions have the same symptom for a related reason (the var was simply never forwarded at all).

## Changes

- `docker-compose.yml`: renamed `NEXT_PUBLIC_DD_VERSION` to `NEXT_PUBLIC_DD_VERSION_FRONTEND` in the `frontend` service's `environment` block.
- `docker-compose.dev.yml`: added `NEXT_PUBLIC_DD_VERSION_FRONTEND=${NEXT_PUBLIC_DD_VERSION_FRONTEND:-1.0.0}` to the `frontend` service's `environment` block.

## Test plan

- [ ] `docker compose up`, set `NEXT_PUBLIC_DD_VERSION_FRONTEND=1.2.3` in `.env`, confirm RUM sessions in Datadog report version `1.2.3` instead of `1.0.0`.
- [ ] Same check against `docker-compose.dev.yml`.

Made with [Cursor](https://cursor.com)